### PR TITLE
Follow standard node practice for disconnect callback

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -270,7 +270,7 @@ Client.prototype.disconnect = function(cb) {
        */
       self.emit('disconnected', self.metrics);
       if (cb) {
-        cb(self.metrics);
+        cb(null, self.metrics);
       }
 
     });


### PR DESCRIPTION
It's a standard practice in node.js to have error as the first argument in a callback. If we send and object as the first argument, automatic promisification (like in [bluebird](http://bluebirdjs.com/docs/api/promise.promisify.html)) of the `disconnect` method breaks.