### PR TITLE
Support building against librdkafka-dev package

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,29 +1,36 @@
 {
+  "variables": {
+      # may be redefined in command line on configuration stage
+      "BUILD_LIBRDKAFKA%": "<!(echo ${BUILD_LIBRDKAFKA:-1})",
+  },
   "targets": [
     {
       "target_name": "node-librdkafka",
-      "sources": [
-        "src/common.cc",
-        "src/errors.cc",
-        "src/config.cc",
-        "src/topic.cc",
-        "src/callbacks.cc",
-        "src/connection.cc",
-        "src/message.cc",
-        "src/consumer.cc",
-        "src/producer.cc",
-        "src/workers.cc",
-        "src/binding.cc"
-      ],
-      "dependencies": [
-        "<(module_root_dir)/deps/librdkafka.gyp:librdkafka_cpp"
-      ],
+      "sources": [ "<!@(ls -1 src/*.cc)", ],
       "include_dirs": [
-        "<(module_root_dir)/deps/librdkafka/src-cpp",
         "<!(node -e \"require('nan')\")",
         "<(module_root_dir)/"
       ],
       'conditions': [
+        [ "<(BUILD_LIBRDKAFKA)==1",
+            {
+                "dependencies": [
+                    "<(module_root_dir)/deps/librdkafka.gyp:librdkafka_cpp"
+                ],
+                "include_dirs": [ "deps/librdkafka/src-cpp" ],
+            },
+            # Else link against globally installed rdkafka and use
+            # globally installed headers.  On Debian, you should
+            # install the librdkafka1, librdkafka++1, and librdkafka-dev
+            # .deb packages.
+            {
+                "libraries": ["-lrdkafka", "-lrdkafka++"],
+                "include_dirs": [
+                    "/usr/include/librdkafka",
+                    "/usr/local/include/librdkafka"
+                ],
+            },
+        ],
         [
           'OS=="linux"',
           {


### PR DESCRIPTION
In our setup we use docker to perform 'npm i' and to build all native dependencies in the same environment they will run in production. We maintain our own apt repository with `librdkafka@0.9.1` debian package, so we would like to build against the same version of the software as will run in production.

With this change I add a `BUILD_LIBRDKAFKA` env variable, defaulting to true, so in the default environment the behaviour of the build script would be unchanged. However, if you `export  BUILD_LIBRDKAFKA=0` before installing the package it will link to the librdkafka package installed on the machine. 

You could also benefit from this: if you install librdkafka locally and `node-gyp --BUILD_LIBRDKAFKA=0 rebuild` it will save you time on development since it will not recompile librdkafka sources every time.

In case you don't like this idea/change - feel free to close this PR, we will make our own fork and will be running it in production.