### PR TITLE
Update Default Partition Logic. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,11 @@ producer.on('ready', function() {
     // converted to a Buffer automatically, but we're being
     // explicit here for the sake of example.
     message: new Buffer('Awesome message'),
-
+    // for keyed messages, we also specify the key - note that this field is optional
+    key: 'Stormwind',
+    // optionally we can manually specify a partition for the message
+    // this defaults to -1 - which will use librdkafka's default partitioner (consistent random for keyed messages, random for unkeyed messages)
+    partition: 0,
     // The topic object we created above
     topic: topic
   }, function(err) {

--- a/src/producer.cc
+++ b/src/producer.cc
@@ -415,7 +415,7 @@ ProducerMessage::ProducerMessage(v8::Local<v8::Object> obj, Topic * topic):
   m_is_empty(true) {
   // We have this bad boy now
 
-  m_partition = GetParameter<int64_t>(obj, "partition", 0);
+  m_partition = GetParameter<int64_t>(obj, "partition", -1);
 
   if (m_partition < 0) {
     m_partition = RdKafka::Topic::PARTITION_UA;  // this is just -1

--- a/src/producer.cc
+++ b/src/producer.cc
@@ -415,7 +415,7 @@ ProducerMessage::ProducerMessage(v8::Local<v8::Object> obj, Topic * topic):
   m_is_empty(true) {
   // We have this bad boy now
 
-  m_partition = GetParameter<int64_t>(obj, "partition", -1);
+  m_partition = GetParameter<int64_t>(obj, "partition", RdKafka::Topic::PARTITION_UA);
 
   if (m_partition < 0) {
     m_partition = RdKafka::Topic::PARTITION_UA;  // this is just -1

--- a/src/producer.cc
+++ b/src/producer.cc
@@ -415,7 +415,7 @@ ProducerMessage::ProducerMessage(v8::Local<v8::Object> obj, Topic * topic):
   m_is_empty(true) {
   // We have this bad boy now
 
-  m_partition = 
+  m_partition =
     GetParameter<int64_t>(obj, "partition", RdKafka::Topic::PARTITION_UA);
 
   if (m_partition < 0) {

--- a/src/producer.cc
+++ b/src/producer.cc
@@ -415,7 +415,8 @@ ProducerMessage::ProducerMessage(v8::Local<v8::Object> obj, Topic * topic):
   m_is_empty(true) {
   // We have this bad boy now
 
-  m_partition = GetParameter<int64_t>(obj, "partition", RdKafka::Topic::PARTITION_UA);
+  m_partition = 
+    GetParameter<int64_t>(obj, "partition", RdKafka::Topic::PARTITION_UA);
 
   if (m_partition < 0) {
     m_partition = RdKafka::Topic::PARTITION_UA;  // this is just -1


### PR DESCRIPTION
- Update default partition to -1 so that use of librdkafka's default partitioner is used when one is not specified (Currently defaults to partition 0.)
- Update documentation to indicate key and partition can be specified when producing a message