### PR TITLE
Refactor rebalance callback to more pure implementation

### DIFF
--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -75,18 +75,14 @@ var testCase = new TestCase('Interoperability tests', function() {
 
         crypto.randomBytes(4096, function(ex, buffer) {
 
-          consumer.on('rebalance', function(e) {
-            if (e.code === 500) {
-              setTimeout(function() {
-                producer.produce({
-                  message: buffer,
-                  topic: topic
-                }, function(err) {
-                  t.ifError(err);
-                });
-              }, 1000);
-            }
-          });
+          var pT = setInterval(function() {
+            producer.produce({
+              message: buffer,
+              topic: topic
+            }, function(err) {
+              t.ifError(err);
+            });
+          }, 2000);
 
           var tt = setInterval(function() {
             if (!producer.isConnected()) {
@@ -116,6 +112,7 @@ var testCase = new TestCase('Interoperability tests', function() {
               }
 
               clearInterval(tt);
+              clearInterval(pT);
 
               if (err) {
                 return cb(err);

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -42,8 +42,30 @@ function KafkaConsumer(conf, topicConf) {
 
   var onRebalance = conf.rebalance_cb;
 
-  // Delete it because it messes other things up
-  delete conf.rebalance_cb;
+  var self = this;
+
+  // If rebalance is undefined we don't want any part of this
+  if (onRebalance && typeof onRebalance === 'boolean') {
+    conf.rebalance_cb = function(e) {
+      // That's it
+      if (e.code === 500 /*CODES.REBALANCE.PARTITION_ASSIGNMENT*/) {
+        self.assign(e.assignment);
+      } else if (e.code === 501 /*CODES.REBALANCE.PARTITION_UNASSIGNMENT*/) {
+        self.unassign(e.assignment);
+      }
+    };
+  } else if (onRebalance && typeof onRebalance === 'function') {
+    /*
+     * Once this is opted in to, that's it. It's going to manually rebalance
+     * forever. There is no way to unset config values in librdkafka, just
+     * a way to override them.
+     */
+
+     conf.rebalance_cb = function(e) {
+       self.emit('rebalance', e);
+       onRebalance.call(self, e);
+     };
+  }
 
 
   /**
@@ -62,42 +84,6 @@ function KafkaConsumer(conf, topicConf) {
    */
 
   Client.call(this, conf, Kafka.KafkaConsumer, topicConf);
-
-  var self = this;
-
-  if (onRebalance !== false) {
-    // If rebalance is specifically false we don't want any part of this
-
-    if (typeof onRebalance !== 'function') {
-      onRebalance = function(e) {
-        // That's it
-        self.assign(e.assignments);
-      };
-    }
-
-  }
-
-  /*
-   * Once this is opted in to, that's it. It's going to manually rebalance
-   * forever. There is no way to unset config values in librdkafka, just
-   * a way to override them.
-   */
-
-  if (onRebalance) {
-    /**
-     * Rebalance event. Called when the KafkaConsumer is rebalancing.
-     *
-     * @event KafkaConsumer#rebalance
-     * @type {object}
-     * @property {number} code - whether the rebalance was an assignment or
-     * an unassignment
-     */
-    this._client.onRebalance(function(e) {
-      self.emit('rebalance', e);
-      onRebalance.call(self, e);
-    });
-
-  }
 
   this.globalConfig = conf;
   this.topicConfig = topicConf;

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -40,6 +40,12 @@ function KafkaConsumer(conf, topicConf) {
     return new KafkaConsumer(conf, topicConf);
   }
 
+  var onRebalance = conf.rebalance_cb;
+
+  // Delete it because it messes other things up
+  delete conf.rebalance_cb;
+
+
   /**
    * KafkaConsumer message.
    *
@@ -59,17 +65,39 @@ function KafkaConsumer(conf, topicConf) {
 
   var self = this;
 
-  /**
-   * Rebalance event. Called when the KafkaConsumer is rebalancing.
-   *
-   * @event KafkaConsumer#rebalance
-   * @type {object}
-   * @property {number} code - whether the rebalance was an assignment or
-   * an unassignment
+  if (onRebalance !== false) {
+    // If rebalance is specifically false we don't want any part of this
+
+    if (typeof onRebalance !== 'function') {
+      onRebalance = function(e) {
+        // That's it
+        self.assign(e.assignments);
+      };
+    }
+
+  }
+
+  /*
+   * Once this is opted in to, that's it. It's going to manually rebalance
+   * forever. There is no way to unset config values in librdkafka, just
+   * a way to override them.
    */
-  this._client.onRebalance(function(e) {
-    self.emit('rebalance', e);
-  });
+
+  if (onRebalance) {
+    /**
+     * Rebalance event. Called when the KafkaConsumer is rebalancing.
+     *
+     * @event KafkaConsumer#rebalance
+     * @type {object}
+     * @property {number} code - whether the rebalance was an assignment or
+     * an unassignment
+     */
+    this._client.onRebalance(function(e) {
+      self.emit('rebalance', e);
+      onRebalance.call(self, e);
+    });
+
+  }
 
   this.globalConfig = conf;
   this.topicConfig = topicConf;

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -386,7 +386,13 @@ void Delivery::dr_cb(RdKafka::Message &message) {
 
 // Rebalance CB
 
-/*
+RebalanceDispatcher::RebalanceDispatcher() {}
+RebalanceDispatcher::~RebalanceDispatcher() {}
+
+void RebalanceDispatcher::Add(const rebalance_event_t &e) {
+  scoped_mutex_lock lock(async_lock);
+  events.push_back(e);
+}
 
 void RebalanceDispatcher::Flush() {
   Nan::HandleScope scope;
@@ -447,16 +453,18 @@ void RebalanceDispatcher::Flush() {
     Dispatch(argc, argv);
   }
 }
-*/
-Rebalance::Rebalance(Nan::Callback &cb) {}
+
+Rebalance::Rebalance(v8::Local<v8::Function> &cb) {
+  dispatcher.AddCallback(cb);
+}
 Rebalance::~Rebalance() {}
 
 void Rebalance::rebalance_cb(RdKafka::KafkaConsumer *consumer,
   RdKafka::ErrorCode err,
   std::vector<RdKafka::TopicPartition*> &partitions) {
 
-  // dispatcher.Add(rebalance_event_t(err, partitions));
-  // dispatcher.Execute();
+  dispatcher.Add(rebalance_event_t(err, partitions));
+  dispatcher.Execute();
 
 }
 

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -386,13 +386,7 @@ void Delivery::dr_cb(RdKafka::Message &message) {
 
 // Rebalance CB
 
-RebalanceDispatcher::RebalanceDispatcher() {}
-RebalanceDispatcher::~RebalanceDispatcher() {}
-
-void RebalanceDispatcher::Add(const rebalance_event_t &e) {
-  scoped_mutex_lock lock(async_lock);
-  events.push_back(e);
-}
+/*
 
 void RebalanceDispatcher::Flush() {
   Nan::HandleScope scope;
@@ -453,26 +447,17 @@ void RebalanceDispatcher::Flush() {
     Dispatch(argc, argv);
   }
 }
-
+*/
+Rebalance::Rebalance(Nan::Callback &cb) {}
 Rebalance::~Rebalance() {}
-Rebalance::Rebalance(NodeKafka::Consumer* that) :
-  that_(that) {
-  eof_cnt = 0;
-}
 
 void Rebalance::rebalance_cb(RdKafka::KafkaConsumer *consumer,
   RdKafka::ErrorCode err,
   std::vector<RdKafka::TopicPartition*> &partitions) {
-  if (err == RdKafka::ERR__ASSIGN_PARTITIONS) {
-    that_->Assign(partitions);
-  } else {
-    that_->Unassign();
-  }
 
-  dispatcher.Add(rebalance_event_t(err, partitions));
-  dispatcher.Execute();
+  // dispatcher.Add(rebalance_event_t(err, partitions));
+  // dispatcher.Execute();
 
-  eof_cnt = 0;
 }
 
 // Partitioner callback

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -425,6 +425,29 @@ void RebalanceDispatcher::Flush() {
       break;
     }
 
+    std::vector<rebalance_topic_partition_t> parts = _events[i].partitions;
+
+    v8::Local<v8::Array> tp_array = Nan::New<v8::Array>();
+
+    for (size_t i = 0; i < parts.size(); i++) {
+      v8::Local<v8::Object> tp_obj = Nan::New<v8::Object>();
+      rebalance_topic_partition_t tp = parts[i];
+
+      Nan::Set(tp_obj, Nan::New("topic").ToLocalChecked(),
+        Nan::New<v8::String>(tp.topic.c_str()).ToLocalChecked());
+      Nan::Set(tp_obj, Nan::New("partition").ToLocalChecked(),
+        Nan::New<v8::Number>(tp.partition));
+
+      if (tp.offset >= 0) {
+        Nan::Set(tp_obj, Nan::New("offset").ToLocalChecked(),
+          Nan::New<v8::Number>(tp.offset));
+      }
+
+      tp_array->Set(i, tp_obj);
+    }
+    // Now convert the TopicPartition list to a JS array
+    Nan::Set(jsobj, Nan::New("assignment").ToLocalChecked(), tp_array);
+
     argv[0] = jsobj;
 
     Dispatch(argc, argv);

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -460,12 +460,9 @@ Rebalance::Rebalance(v8::Local<v8::Function> &cb) {
 Rebalance::~Rebalance() {}
 
 void Rebalance::rebalance_cb(RdKafka::KafkaConsumer *consumer,
-  RdKafka::ErrorCode err,
-  std::vector<RdKafka::TopicPartition*> &partitions) {
-
+    RdKafka::ErrorCode err, std::vector<RdKafka::TopicPartition*> &partitions) {
   dispatcher.Add(rebalance_event_t(err, partitions));
   dispatcher.Execute();
-
 }
 
 // Partitioner callback

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -145,7 +145,7 @@ struct rebalance_topic_partition_t {
   int partition;
   int64_t offset;
 
-  rebalance_topic_partition_t(std::string p_topic, int p_partition, int64_t p_offset):
+  rebalance_topic_partition_t(std::string p_topic, int p_partition, int64_t p_offset):  // NOLINT
     topic(p_topic),
     partition(p_partition),
     offset(p_offset) {}
@@ -167,11 +167,9 @@ struct rebalance_event_t {
       rebalance_topic_partition_t tp(
         topic_partition->topic(),
         topic_partition->partition(),
-        topic_partition->offset()
-      );
+        topic_partition->offset());
 
       partitions.push_back(tp);
-
     }
   }
 };

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -174,28 +174,16 @@ struct rebalance_event_t {
   }
 };
 
-class RebalanceDispatcher : public Dispatcher {
- public:
-  RebalanceDispatcher();
-  ~RebalanceDispatcher();
-  void Add(const rebalance_event_t &);
-  void Flush();
- protected:
-  std::vector<rebalance_event_t> events;
-};
 
 class Rebalance : public RdKafka::RebalanceCb {
  public:
-  explicit Rebalance(NodeKafka::Consumer* that);
+  explicit Rebalance(Nan::Callback &);
   ~Rebalance();
-  // NAN_DISALLOW_ASSIGN_COPY_MOVE?
-  NodeKafka::Consumer* const that_;
 
   void rebalance_cb(RdKafka::KafkaConsumer *, RdKafka::ErrorCode,
     std::vector<RdKafka::TopicPartition*> &);
-  RebalanceDispatcher dispatcher;
  private:
-  int eof_cnt;
+  v8::Persistent<v8::Function> m_cb;
 };
 
 class Partitioner : public RdKafka::PartitionerCb {

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -174,14 +174,25 @@ struct rebalance_event_t {
   }
 };
 
+class RebalanceDispatcher : public Dispatcher {
+ public:
+  RebalanceDispatcher();
+  ~RebalanceDispatcher();
+  void Add(const rebalance_event_t &);
+  void Flush();
+ protected:
+  std::vector<rebalance_event_t> events;
+};
 
 class Rebalance : public RdKafka::RebalanceCb {
  public:
-  explicit Rebalance(Nan::Callback &);
+  explicit Rebalance(v8::Local<v8::Function>&);
   ~Rebalance();
 
   void rebalance_cb(RdKafka::KafkaConsumer *, RdKafka::ErrorCode,
     std::vector<RdKafka::TopicPartition*> &);
+
+  RebalanceDispatcher dispatcher;
  private:
   v8::Persistent<v8::Function> m_cb;
 };

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -140,14 +140,40 @@ class Delivery : public RdKafka::DeliveryReportCb {
 
 // Rebalance dispatcher
 
+struct rebalance_topic_partition_t {
+  std::string topic;
+  int partition;
+  int64_t offset;
+
+  rebalance_topic_partition_t(std::string p_topic, int p_partition, int64_t p_offset):
+    topic(p_topic),
+    partition(p_partition),
+    offset(p_offset) {}
+};
+
 struct rebalance_event_t {
   RdKafka::ErrorCode err;
-  std::vector<RdKafka::TopicPartition*> partitions;
+  std::vector<rebalance_topic_partition_t> partitions;
 
-  rebalance_event_t(RdKafka::ErrorCode _err,
-        std::vector<RdKafka::TopicPartition*> _partitions):
-        err(_err),
-        partitions(_partitions) {}
+  rebalance_event_t(RdKafka::ErrorCode p_err,
+        std::vector<RdKafka::TopicPartition*> p_partitions):
+        err(p_err) {
+    // Iterate over the topic partitions because we won't have them later
+    for (size_t topic_partition_i = 0;
+      topic_partition_i < p_partitions.size(); topic_partition_i++) {
+      RdKafka::TopicPartition* topic_partition =
+        p_partitions[topic_partition_i];
+
+      rebalance_topic_partition_t tp(
+        topic_partition->topic(),
+        topic_partition->partition(),
+        topic_partition->offset()
+      );
+
+      partitions.push_back(tp);
+
+    }
+  }
 };
 
 class RebalanceDispatcher : public Dispatcher {

--- a/src/common.h
+++ b/src/common.h
@@ -18,6 +18,10 @@
 
 #include "deps/librdkafka/src-cpp/rdkafkacpp.h"
 
+typedef std::vector<const RdKafka::BrokerMetadata*> BrokerMetadataList;
+typedef std::vector<const RdKafka::PartitionMetadata*> PartitionMetadataList;
+typedef std::vector<const RdKafka::TopicMetadata *> TopicMetadataList;
+
 namespace NodeKafka {
 
 void Log(std::string);
@@ -44,6 +48,18 @@ class scoped_mutex_lock {
  private:
   uv_mutex_t &async_lock;
 };
+
+namespace TopicPartition {
+
+v8::Local<v8::Array> ToV8Array(std::vector<RdKafka::TopicPartition*>);
+
+}
+
+namespace Metadata {
+
+v8::Local<v8::Object> ToV8Object(RdKafka::Metadata*);
+
+}  // namespace Metadata
 
 }  // namespace NodeKafka
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -71,7 +71,6 @@ Conf * Conf::create(RdKafka::Conf::ConfType type, v8::Local<v8::Object> object, 
   }
 
   return rdconf;
-
 }
 
 void Conf::listen() {

--- a/src/config.h
+++ b/src/config.h
@@ -28,9 +28,11 @@ class Conf : public RdKafka::Conf {
   static Conf* create(RdKafka::Conf::ConfType, v8::Local<v8::Object>, std::string &);  // NOLINT
 
   static void DumpConfig(std::list<std::string> *);
+
+  void listen();
+  void stop();
  protected:
-  bool m_has_rebalance_cb;
-  bool m_has_partitioner_cb;
+  NodeKafka::Callbacks::Rebalance * m_rebalance_cb = NULL;
 };
 
 }  // namespace NodeKafka

--- a/src/config.h
+++ b/src/config.h
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <vector>
 #include <list>
+#include <string>
 
 #include "deps/librdkafka/src-cpp/rdkafkacpp.h"
 #include "src/common.h"
@@ -26,7 +27,6 @@ class Conf : public RdKafka::Conf {
   ~Conf();
 
   static Conf* create(RdKafka::Conf::ConfType, v8::Local<v8::Object>, std::string &);  // NOLINT
-
   static void DumpConfig(std::list<std::string> *);
 
   void listen();

--- a/src/config.h
+++ b/src/config.h
@@ -17,16 +17,21 @@
 
 #include "deps/librdkafka/src-cpp/rdkafkacpp.h"
 #include "src/common.h"
+#include "src/callbacks.h"
 
 namespace NodeKafka {
-namespace Config {
 
-void DumpConfig(std::list<std::string> *);
-template<typename T> void LoadParameter(v8::Local<v8::Object>, std::string, T &);  // NOLINT
-std::string GetValue(RdKafka::Conf*, const std::string);
-RdKafka::Conf* Create(RdKafka::Conf::ConfType, v8::Local<v8::Object>, std::string &);  // NOLINT
+class Conf : public RdKafka::Conf {
+ public:
+  ~Conf();
 
-}  // namespace Config
+  static Conf* create(RdKafka::Conf::ConfType, v8::Local<v8::Object>, std::string &);  // NOLINT
+
+  static void DumpConfig(std::list<std::string> *);
+ protected:
+  bool m_has_rebalance_cb;
+  bool m_has_partitioner_cb;
+};
 
 }  // namespace NodeKafka
 

--- a/src/connection.cc
+++ b/src/connection.cc
@@ -36,7 +36,7 @@ namespace NodeKafka {
  * @sa NodeKafka::Client
  */
 
-Connection::Connection(RdKafka::Conf* gconfig, RdKafka::Conf* tconfig):
+Connection::Connection(Conf* gconfig, Conf* tconfig):
   m_event_cb(),
   m_gconfig(gconfig),
   m_tconfig(tconfig) {

--- a/src/connection.h
+++ b/src/connection.h
@@ -63,7 +63,7 @@ class Connection : public Nan::ObjectWrap {
   virtual void DeactivateDispatchers() = 0;
 
  protected:
-  Connection(RdKafka::Conf*, RdKafka::Conf*);
+  Connection(Conf*, Conf*);
   ~Connection();
 
   static Nan::Persistent<v8::Function> constructor;
@@ -72,8 +72,8 @@ class Connection : public Nan::ObjectWrap {
   bool m_has_been_disconnected;
   bool m_is_closing;
 
-  RdKafka::Conf* m_gconfig;
-  RdKafka::Conf* m_tconfig;
+  Conf* m_gconfig;
+  Conf* m_tconfig;
   std::string m_errstr;
 
   uv_mutex_t m_connection_lock;

--- a/src/consumer.cc
+++ b/src/consumer.cc
@@ -37,11 +37,8 @@ consumer_commit_t::consumer_commit_t() {
  * @sa NodeKafka::Client
  */
 
-Consumer::Consumer(RdKafka::Conf* gconfig, RdKafka::Conf* tconfig):
+Consumer::Consumer(Conf* gconfig, Conf* tconfig):
   Connection(gconfig, tconfig) {
-    m_is_subscribed = false;
-    m_is_manually_rebalancing = false;
-
     std::string errstr;
 
     m_gconfig->set("default_topic_conf", m_tconfig, errstr);
@@ -73,6 +70,13 @@ Baton Consumer::Connect() {
 }
 
 void Consumer::ActivateDispatchers() {
+  // Listen to global config
+  m_gconfig->listen();
+
+  // Listen to non global config
+  // tconfig->listen();
+
+  // This should be refactored to config based management
   m_event_cb.dispatcher.Activate();
 }
 
@@ -100,6 +104,10 @@ Baton Consumer::Disconnect() {
 }
 
 void Consumer::DeactivateDispatchers() {
+  // Stop listening to the config dispatchers
+  m_gconfig->stop();
+
+  // Also this one
   m_event_cb.dispatcher.Deactivate();
 }
 

--- a/src/consumer.h
+++ b/src/consumer.h
@@ -79,7 +79,7 @@ class Consumer : public Connection {
   static Nan::Persistent<v8::Function> constructor;
   static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
-  Consumer(RdKafka::Conf *, RdKafka::Conf *);
+  Consumer(Conf *, Conf *);
   ~Consumer();
 
  private:
@@ -87,8 +87,7 @@ class Consumer : public Connection {
 
   std::vector<RdKafka::TopicPartition*> m_partitions;
   int m_partition_cnt;
-  bool m_is_subscribed;
-  bool m_is_manually_rebalancing;
+  bool m_is_subscribed = false;
 
   // Node methods
   static NAN_METHOD(NodeConnect);

--- a/src/consumer.h
+++ b/src/consumer.h
@@ -47,8 +47,6 @@ struct consumer_commit_t {
 
 class Consumer : public Connection {
  public:
-  friend class NodeKafka::Callbacks::Rebalance;
-
   static void Init(v8::Local<v8::Object>);
   static v8::Local<v8::Object> NewInstance(v8::Local<v8::Value>);
 
@@ -77,8 +75,6 @@ class Consumer : public Connection {
   void ActivateDispatchers();
   void DeactivateDispatchers();
 
-  Baton UseManualRebalancing(v8::Local<v8::Function>);
-
  protected:
   static Nan::Persistent<v8::Function> constructor;
   static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
@@ -94,12 +90,7 @@ class Consumer : public Connection {
   bool m_is_subscribed;
   bool m_is_manually_rebalancing;
 
-  Callbacks::Consume m_consume_cb;
-  Callbacks::Rebalance m_rebalance_cb;
-
   // Node methods
-  static NAN_METHOD(NodeOnConsume);
-  static NAN_METHOD(NodeOnRebalance);
   static NAN_METHOD(NodeConnect);
   static NAN_METHOD(NodeSubscribe);
   static NAN_METHOD(NodeSubscribeSync);

--- a/src/consumer.h
+++ b/src/consumer.h
@@ -77,6 +77,8 @@ class Consumer : public Connection {
   void ActivateDispatchers();
   void DeactivateDispatchers();
 
+  Baton UseManualRebalancing(v8::Local<v8::Function>);
+
  protected:
   static Nan::Persistent<v8::Function> constructor;
   static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
@@ -90,6 +92,7 @@ class Consumer : public Connection {
   std::vector<RdKafka::TopicPartition*> m_partitions;
   int m_partition_cnt;
   bool m_is_subscribed;
+  bool m_is_manually_rebalancing;
 
   Callbacks::Consume m_consume_cb;
   Callbacks::Rebalance m_rebalance_cb;

--- a/src/message.cc
+++ b/src/message.cc
@@ -101,7 +101,6 @@ size_t Message::Size() {
 
 void Message::Free(char * data, void * hint) {
   Message* m = static_cast<Message*>(hint);
-  // @note Am I responsible for freeing data as well?
   delete m;
 }
 

--- a/src/producer.cc
+++ b/src/producer.cc
@@ -28,7 +28,7 @@ namespace NodeKafka {
  * @sa NodeKafka::Connection
  */
 
-Producer::Producer(RdKafka::Conf* gconfig, RdKafka::Conf* tconfig):
+Producer::Producer(Conf* gconfig, Conf* tconfig):
   Connection(gconfig, tconfig),
   m_dr_cb(),
   m_partitioner_cb() {
@@ -109,14 +109,14 @@ void Producer::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
 
   std::string errstr;
 
-  RdKafka::Conf* gconfig =
+  Conf* gconfig =
     Conf::create(RdKafka::Conf::CONF_GLOBAL, info[0]->ToObject(), errstr);
 
   if (!gconfig) {
     return Nan::ThrowError(errstr.c_str());
   }
 
-  RdKafka::Conf* tconfig =
+  Conf* tconfig =
     Conf::create(RdKafka::Conf::CONF_TOPIC, info[1]->ToObject(), errstr);
 
   if (!tconfig) {

--- a/src/producer.cc
+++ b/src/producer.cc
@@ -110,14 +110,14 @@ void Producer::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   std::string errstr;
 
   RdKafka::Conf* gconfig =
-    Config::Create(RdKafka::Conf::CONF_GLOBAL, info[0]->ToObject(), errstr);
+    Conf::create(RdKafka::Conf::CONF_GLOBAL, info[0]->ToObject(), errstr);
 
   if (!gconfig) {
     return Nan::ThrowError(errstr.c_str());
   }
 
   RdKafka::Conf* tconfig =
-    Config::Create(RdKafka::Conf::CONF_TOPIC, info[1]->ToObject(), errstr);
+    Conf::create(RdKafka::Conf::CONF_TOPIC, info[1]->ToObject(), errstr);
 
   if (!tconfig) {
     // No longer need this since we aren't instantiating anything

--- a/src/producer.h
+++ b/src/producer.h
@@ -66,7 +66,7 @@ class Producer : public Connection {
   static Nan::Persistent<v8::Function> constructor;
   static void New(const Nan::FunctionCallbackInfo<v8::Value>&);
 
-  Producer(RdKafka::Conf*, RdKafka::Conf*);
+  Producer(Conf*, Conf*);
   ~Producer();
 
  private:

--- a/src/topic.cc
+++ b/src/topic.cc
@@ -85,7 +85,7 @@ void Topic::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   std::string errstr;
 
   RdKafka::Conf* config =
-    Config::Create(RdKafka::Conf::CONF_TOPIC, info[1]->ToObject(), errstr);
+    Conf::create(RdKafka::Conf::CONF_TOPIC, info[1]->ToObject(), errstr);
 
   if (!config) {
     return Nan::ThrowError(errstr.c_str());

--- a/src/workers.h
+++ b/src/workers.h
@@ -158,7 +158,7 @@ class ConnectionMetadata : public ErrorAwareWorker {
   std::string topic_;
   int timeout_ms_;
 
-  RdKafka::Metadata* metadata_;
+  RdKafka::Metadata* m_metadata;
 
   // Now this is the data that will get translated in the OK callback
 };


### PR DESCRIPTION
Rebalance callback can now be set like any other configuration value. If it is omitted, we rely on the internal `librdkafka` rebalance callback. If you set it to `true`, it will use a node implementation (and expose the event to you). If you provide a function, you will do the assignment yourself, and it will emit the event.