### PR TITLE
remove -lsasl2 from default build options in bindings.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,6 @@
         "<!(node -e \"require('nan')\")",
         "<(module_root_dir)/"
       ],
-      "libraries" : ['-lsasl2'],
       'conditions': [
         [ "<(BUILD_LIBRDKAFKA)==1",
             {


### PR DESCRIPTION
Turns out that you can't build without sasl currently as -lsasl2 is always set in bindings.gyp, so i removed it.

As WITH_SASL=1 is the default condition and this sets -lsasl2 anyway this won't change the default behavior, but will allow WITH_SASL=0 builds to work.