### PR TITLE
Support passing v8 regular expressions into subscribe

### DIFF
--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -226,9 +226,9 @@ KafkaConsumer.prototype.consume = function(topics, cb) {
   var self = this;
   // If topics is set and is an array or a string, or if we have both
   // parameters, run it like this.
-  if ((topics && (Array.isArray(topics) || typeof topics === 'string'))) {
+  if ((topics && (Array.isArray(topics) || (typeof topics === 'string' || topics instanceof RegExp)))) {
 
-    if (typeof topics === 'string') {
+    if (typeof topics === 'string' || topics instanceof RegExp) {
       topics = [topics];
     } else if (!Array.isArray(topics)) {
       throw new TypeError('"topics" must be an array or a string');

--- a/lib/util/topicReadable.js
+++ b/lib/util/topicReadable.js
@@ -58,8 +58,8 @@ function TopicReadable(consumer, topics, options) {
   }
 
   if (!Array.isArray(topics)) {
-    if (typeof topics !== 'string') {
-      throw new TypeError('"topics" argument must be a string or an array');
+    if (typeof topics !== 'string' && !(topics instanceof RegExp)) {
+      throw new TypeError('"topics" argument must be a string, regex, or an array');
     } else {
       topics = [topics];
     }

--- a/src/common.h
+++ b/src/common.h
@@ -49,17 +49,25 @@ class scoped_mutex_lock {
   uv_mutex_t &async_lock;
 };
 
+namespace Conversion {
+
+namespace Topic {
+  std::vector<std::string> ToStringVector(v8::Local<v8::Array>);
+}  // namespace Topic
+
 namespace TopicPartition {
 
 v8::Local<v8::Array> ToV8Array(std::vector<RdKafka::TopicPartition*>);
 
-}
+}  // namespace TopicPartition
 
 namespace Metadata {
 
 v8::Local<v8::Object> ToV8Object(RdKafka::Metadata*);
 
 }  // namespace Metadata
+
+}  // namespace Conversion
 
 }  // namespace NodeKafka
 

--- a/src/consumer.cc
+++ b/src/consumer.cc
@@ -433,7 +433,8 @@ NAN_METHOD(Consumer::NodeAssignments) {
     return;
   }
 
-  info.GetReturnValue().Set(TopicPartition::ToV8Array(consumer->m_partitions));
+  info.GetReturnValue().Set(
+    Conversion::TopicPartition::ToV8Array(consumer->m_partitions));
 }
 
 NAN_METHOD(Consumer::NodeAssign) {
@@ -648,7 +649,7 @@ NAN_METHOD(Consumer::NodeSubscribe) {
   v8::Local<v8::Array> topicsArray = info[0].As<v8::Array>();
   v8::Local<v8::Function> cb = info[1].As<v8::Function>();
 
-  std::vector<std::string> topics = v8ArrayToStringVector(topicsArray);
+  std::vector<std::string> topics = Conversion::Topic::ToStringVector(topicsArray);  // NOLINT
 
   if (topics.empty()) {
      Nan::ThrowError("Please provide an array of topics to subscribe to");
@@ -676,7 +677,7 @@ NAN_METHOD(Consumer::NodeSubscribeSync) {
   Consumer* consumer = ObjectWrap::Unwrap<Consumer>(info.This());
 
   v8::Local<v8::Array> topicsArray = info[0].As<v8::Array>();
-  std::vector<std::string> topics = v8ArrayToStringVector(topicsArray);
+  std::vector<std::string> topics = Conversion::Topic::ToStringVector(topicsArray);  // NOLINT
 
   Baton b = consumer->Subscribe(topics);
 

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -54,7 +54,7 @@ void ConnectionMetadata::HandleOKCallback() {
 
   // This is a big one!
   v8::Local<v8::Value> argv[argc] = { Nan::Null(),
-    NodeKafka::Metadata::ToV8Object(m_metadata)};
+    Conversion::Metadata::ToV8Object(m_metadata)};
 
   callback->Call(argc, argv);
 


### PR DESCRIPTION
Currently one can use strings to pass regular expressions into subscribe but it requires knowledge of the wrapping syntax of `librdkafka`'s regular expression pattern. (i.e. `\c \"^${expression}\"`).

The update allows one to pass a v8 regular expression, e.g. `/^topic-.*/` or an array of regular expressions into subscribe and it will automatically convert it to the proper format.