### PR TITLE
Run tests with Node.js 7 on Travis as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 node_js:
 - '4'
 - '6'
+- '7'
 env:
 - WITH_SASL=0
 - WITH_SASL=1


### PR DESCRIPTION
I think I caught some rdkafka error last night when trying to kill a process running with Node 7. Could be completely unrelated.
Either way testing on Node 7 is a good thing.