### PR TITLE
Don't point to the headers in the submodule explicitly

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -399,8 +399,10 @@ _CPP_HEADERS = frozenset([
 # - Anything not following google file name conventions (containing an
 #   uppercase character, such as Python.h or nsStringAPI.h, for example).
 # - Lua headers.
+# - rdkafka.cpp header, because it would be located in different directories depending
+#   on whether it's pulled from librdkafka sources or librdkafka-dev package.
 _THIRD_PARTY_HEADERS_PATTERN = re.compile(
-    r'^(?:[^/]*[A-Z][^/]*\.h|lua\.h|lauxlib\.h|lualib\.h)$')
+    r'^(?:[^/]*[A-Z][^/]*\.h|lua\.h|lauxlib\.h|lualib\.h|rdkafkacpp\.h)$')
 
 
 # Assertion macros.  These are defined in base/logging.h and

--- a/src/binding.h
+++ b/src/binding.h
@@ -12,7 +12,7 @@
 
 #include <nan.h>
 #include <string>
-#include "deps/librdkafka/src-cpp/rdkafkacpp.h"
+#include "rdkafkacpp.h"
 #include "src/common.h"
 #include "src/errors.h"
 #include "src/config.h"

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -14,7 +14,7 @@
 
 #include <vector>
 
-#include "deps/librdkafka/src-cpp/rdkafkacpp.h"
+#include "rdkafkacpp.h"
 #include "src/common.h"
 
 typedef Nan::Persistent<v8::Function,

--- a/src/common.h
+++ b/src/common.h
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-#include "deps/librdkafka/src-cpp/rdkafkacpp.h"
+#include "rdkafkacpp.h"
 
 #include "src/errors.h"
 

--- a/src/config.h
+++ b/src/config.h
@@ -16,7 +16,7 @@
 #include <list>
 #include <string>
 
-#include "deps/librdkafka/src-cpp/rdkafkacpp.h"
+#include "rdkafkacpp.h"
 #include "src/common.h"
 #include "src/callbacks.h"
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <string>
 
-#include "deps/librdkafka/src-cpp/rdkafkacpp.h"
+#include "rdkafkacpp.h"
 
 #include "src/common.h"
 #include "src/errors.h"

--- a/src/consumer.h
+++ b/src/consumer.h
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-#include "deps/librdkafka/src-cpp/rdkafkacpp.h"
+#include "rdkafkacpp.h"
 
 #include "src/common.h"
 #include "src/connection.h"

--- a/src/errors.h
+++ b/src/errors.h
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <string>
 
-#include "deps/librdkafka/src-cpp/rdkafkacpp.h"
+#include "rdkafkacpp.h"
 
 #include "src/common.h"
 

--- a/src/producer.h
+++ b/src/producer.h
@@ -15,7 +15,7 @@
 #include <node_buffer.h>
 #include <string>
 
-#include "deps/librdkafka/src-cpp/rdkafkacpp.h"
+#include "rdkafkacpp.h"
 
 #include "src/common.h"
 #include "src/connection.h"

--- a/src/topic.h
+++ b/src/topic.h
@@ -13,7 +13,7 @@
 #include <nan.h>
 #include <string>
 
-#include "deps/librdkafka/src-cpp/rdkafkacpp.h"
+#include "rdkafkacpp.h"
 
 #include "src/config.h"
 


### PR DESCRIPTION
There're two options to build this repo controlled by the `BUILD_LIBRDKAFKA` parameter. If it's set to 1, the librdkafka sources are built from the submodule, and if it's 0, the `librdkafka-dev` package is used. In the latter case we need to point to the headers from the `librdkafka-dev` package as well, and not explicitly point to the cloned submodule. This is not only inconsistent, but it prevents us from pulling the dependency from github, since NPM doesn't do `git submodule update --init` when installing the deps, so even with `BUILD_LIBRDKAFKA=0` the build fails.

Now when we delete the explicit references to `deps/librdkafka/src-cpp/` exact location of the headers will be resolved by gyp `include_dirs` parameter.

Unfortunately, I've had to exclude the `rdkafkacpp.h` header from the cpplint check. The problem is that cpplint wants us to include a directory where the header is located, but with sources from submodule and librdkafka-dev the directory names would be different..