### PR TITLE
Updated JSDoc for Producer#produce

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -199,7 +199,10 @@ Producer.prototype._produceObject = util.deprecate(function(message, cb) {
  * When this is sent off, there is no guarantee it is delivered. If you need
  * guaranteed delivery, change your *acks* settings, or use delivery reports.
  *
- * @param {Producer~Message} msg - The message object.
+ * @param {string} topic - The topic name to produce to.
+ * @param {number|null} partition - The partition number to produce to.
+ * @param {Buffer|null} message - The message to produce.
+ * @param {string} [key] - The key associated with the message.
  * @throws {LibrdKafkaError} - Throws a librdkafka error if it failed.
  * @return {boolean} - returns an error if it failed, or true if not
  * @see Producer#produce


### PR DESCRIPTION
The JSDoc should be updated after the Producer#produce was deprecated and proper way of producing is by providing `topic`, `partition`, `message` and `key` separately.