### PR TITLE
Added a bunch of new e2e tests 

### DIFF
--- a/e2e/consumer.spec.js
+++ b/e2e/consumer.spec.js
@@ -136,7 +136,7 @@ describe('Consumer', function() {
       t.equal(0, consumer.subscription().length);
     });
 
-    it('should be able to take an empty assignment', function() {
+    xit('should be able to take an empty assignment - EXCLUDED because of https://github.com/Blizzard/node-rdkafka/issues/63', function() {
       consumer.assign([{ topic:'test', partition:0 }]);
       t.equal(1, consumer.assignments().length);
       consumer.assign([]);

--- a/e2e/consumer.spec.js
+++ b/e2e/consumer.spec.js
@@ -71,7 +71,7 @@ describe('Consumer', function() {
 
   });
 
-  describe('consume', function() {
+  describe('subscribe', function() {
 
     var consumer;
     beforeEach(function(done) {
@@ -91,10 +91,57 @@ describe('Consumer', function() {
       });
     });
 
-    it('should be able to take a subscription', function() {
+    it('should be able to subscribe', function() {
+      t.equal(0, consumer.subscription().length);
       consumer.subscribe(['test']);
+      t.equal(1, consumer.subscription().length);
+      t.equal('test', consumer.subscription()[0]);
+      t.equal(0, consumer.assignments().length);
     });
 
+    it('should be able to unsusbcribe', function() {
+      consumer.subscribe(['test']);
+      t.equal(1, consumer.subscription().length);
+      consumer.unsubscribe();
+      t.equal(0, consumer.subscription().length);
+      t.equal(0, consumer.assignments().length);
+    });
+  });
+
+  describe('assign', function() {
+
+    var consumer;
+    beforeEach(function(done) {
+      consumer = new KafkaConsumer(gcfg, {});
+
+      consumer.connect({ timeout: 2000 }, function(err, info) {
+        t.ifError(err);
+        done();
+      });
+
+      eventListener(consumer);
+    });
+
+    afterEach(function(done) {
+      consumer.disconnect(function() {
+        done();
+      });
+    });
+
+    it('should be able to take an assignment', function() {
+      t.equal(0, consumer.assignments().length);
+      consumer.assign([{ topic:'test', partition:0 }]);
+      t.equal(1, consumer.assignments().length);
+      t.equal('test', consumer.assignments()[0].topic);
+      t.equal(0, consumer.subscription().length);
+    });
+
+    it('should be able to take an empty assignment', function() {
+      consumer.assign([{ topic:'test', partition:0 }]);
+      t.equal(1, consumer.assignments().length);
+      consumer.assign([]);
+      t.equal(0, consumer.assignments().length);
+    });
   });
 
   describe('disconnect', function() {

--- a/e2e/producer.spec.js
+++ b/e2e/producer.spec.js
@@ -30,7 +30,6 @@ describe('Producer', function() {
     });
     producer.connect({}, function(err) {
       t.ifError(err);
-
       done();
     });
 
@@ -58,10 +57,12 @@ describe('Producer', function() {
     });
   });
 
-  it('should produce a message with a null payload', function(done) {
+  it('should produce a message with a null payload and null key', function(done) {
+    this.timeout(3000);
+
     var tt = setInterval(function() {
       producer.poll();
-    }, 200).unref();
+    }, 200);
 
     producer.once('delivery-report', function(report) {
       clearInterval(tt);
@@ -69,27 +70,88 @@ describe('Producer', function() {
       t.ok(typeof report.topic === 'string');
       t.ok(typeof report.partition === 'number');
       t.ok(typeof report.offset === 'number');
+      t.ok( report.key === null);
       done();
     });
 
     producer.produce('test', null, null, null);
   });
 
+  xit('should produce a message with an empty payload and empty key (https://github.com/Blizzard/node-rdkafka/issues/36)', function(done) {
+    this.timeout(3000);
+
+    var tt = setInterval(function() {
+      producer.poll();
+    }, 200);
+
+    producer.once('delivery-report', function(report) {
+      clearInterval(tt);
+      t.ok(report !== undefined);
+      t.ok(typeof report.topic === 'string');
+      t.ok(typeof report.partition === 'number');
+      t.ok(typeof report.offset === 'number');
+      t.ok( report.key === '', 'key should be an empty string');
+      done();
+    });
+
+    producer.produce('test', null, new Buffer(''), '');
+  });
+  
+  it('should produce a message with a payload and key', function(done) {
+    this.timeout(3000);
+
+    var tt = setInterval(function() {
+      producer.poll();
+    }, 200);
+
+    producer.once('delivery-report', function(report) {
+      clearInterval(tt);
+      t.ok(report !== undefined);
+      t.ok(typeof report.topic === 'string');
+      t.ok(typeof report.partition === 'number');
+      t.ok(typeof report.offset === 'number');
+      t.equal('key', report.key);
+      done();
+    });
+
+    producer.produce('test', null, new Buffer('value'), 'key');
+  });
+  
+  it('should produce a message to a Topic object', function(done) {
+    this.timeout(3000);
+
+    var tt = setInterval(function() {
+      producer.poll();
+    }, 200);
+
+    var topic = producer.Topic('test', {
+     'request.required.acks': 1
+     //'produce.offset.report': true
+    });
+    
+    producer.once('delivery-report', function(report) {
+      clearInterval(tt);
+      t.ok(report !== undefined);
+      t.ok(typeof report.topic === 'string');
+      t.ok(typeof report.partition === 'number');
+      t.ok(typeof report.offset === 'number');
+      t.equal('key', report.key);
+      done();
+    });
+
+    producer.produce(topic, null, new Buffer('value'), 'key');
+  });
+  
   it('should get 100% deliverability', function(done) {
     this.timeout(3000);
 
     var total = 0;
     var max = 10000;
-    var errors = 0;
-    var started = Date.now();
-
     var verified_received = 0;
-    var exitNextTick = false;
-    var errorsArr = [];
 
     var tt = setInterval(function() {
       producer.poll();
-    }, 200).unref();
+    }, 200);
 
     producer
       .on('delivery-report', function(report) {

--- a/e2e/producer.spec.js
+++ b/e2e/producer.spec.js
@@ -117,31 +117,6 @@ describe('Producer', function() {
     producer.produce('test', null, new Buffer('value'), 'key');
   });
   
-  it('should produce a message to a Topic object', function(done) {
-    this.timeout(3000);
-
-    var tt = setInterval(function() {
-      producer.poll();
-    }, 200);
-
-    var topic = producer.Topic('test', {
-     'request.required.acks': 1
-     //'produce.offset.report': true
-    });
-    
-    producer.once('delivery-report', function(report) {
-      clearInterval(tt);
-      t.ok(report !== undefined);
-      t.ok(typeof report.topic === 'string');
-      t.ok(typeof report.partition === 'number');
-      t.ok(typeof report.offset === 'number');
-      t.equal('key', report.key);
-      done();
-    });
-
-    producer.produce(topic, null, new Buffer('value'), 'key');
-  });
-  
   it('should get 100% deliverability', function(done) {
     this.timeout(3000);
 
@@ -173,4 +148,29 @@ describe('Producer', function() {
 
   });
 
+  it('should produce a message to a Topic object', function(done) {
+    this.timeout(3000);
+
+    var tt = setInterval(function() {
+      producer.poll();
+    }, 200);
+
+    var topic = producer.Topic('test', {
+     'request.required.acks': 1
+     //'produce.offset.report': true
+    });
+    
+    producer.once('delivery-report', function(report) {
+      clearInterval(tt);
+      t.ok(report !== undefined);
+      t.ok(typeof report.topic === 'string');
+      t.ok(typeof report.partition === 'number');
+      t.ok(typeof report.offset === 'number');
+      t.equal('key', report.key);
+      done();
+    });
+
+    producer.produce(topic, null, new Buffer('value'), 'key');
+  });
+  
 });


### PR DESCRIPTION
To help catch regressions early, we've added a bunch of new tests to the e2e suites. 

The assignment test in consumer.spec.js crashes once in a while:
```
*** ../deps/librdkafka/src/rdkafka_cgrp.c:790:rd_kafka_cgrp_partitions_fetch_start: assert: rkcg->rkcg_assigned_cnt <= (rkcg->rkcg_assignment ? rkcg->rkcg_assignment->cnt : 0) ***
Aborted (core dumped)
```
Is it because we're calling it incorrectly or is there a bug somewhere ?