### PR TITLE
Added message payload in the delivery report object

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The library will throw an error if the value you send in is invalid.
 
 The library currently supports the following callbacks:
 * `partitioner_cb`
-* `dr_cb`
+* `dr_cb` or `dr_msg_cb`
 * `event_cb`
 
 ### SASL Support

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -88,8 +88,9 @@ describe('Consumer/Producer', function() {
 
       var offset;
 
-      producer.once('delivery-report', function(report) {
+      producer.once('delivery-report', function(err, report) {
         clearInterval(tt);
+        t.ifError(err);
         offset = report.offset;
       });
 
@@ -134,9 +135,10 @@ describe('Consumer/Producer', function() {
         producer.poll();
       }, 100);
 
-      producer.once('delivery-report', function(report) {
+      producer.once('delivery-report', function(err, report) {
         //console.log('delivery-report: ' + JSON.stringify(report));
         clearInterval(tt);
+        t.ifError(err);
         t.equal(topic, report.topic, 'invalid delivery-report topic');
         t.equal(key, report.key, 'invalid delivery-report key');
         t.ok(report.offset >= 0, 'invalid delivery-report offset');

--- a/e2e/producer.spec.js
+++ b/e2e/producer.spec.js
@@ -64,8 +64,9 @@ describe('Producer', function() {
       producer.poll();
     }, 200);
 
-    producer.once('delivery-report', function(report) {
+    producer.once('delivery-report', function(err, report) {
       clearInterval(tt);
+      t.ifError(err);
       t.ok(report !== undefined);
       t.ok(typeof report.topic === 'string');
       t.ok(typeof report.partition === 'number');
@@ -104,8 +105,9 @@ describe('Producer', function() {
       producer.poll();
     }, 200);
 
-    producer.once('delivery-report', function(report) {
+    producer.once('delivery-report', function(err, report) {
       clearInterval(tt);
+      t.ifError(err);
       t.ok(report !== undefined);
       t.ok(typeof report.topic === 'string');
       t.ok(typeof report.partition === 'number');
@@ -129,7 +131,8 @@ describe('Producer', function() {
     }, 200);
 
     producer
-      .on('delivery-report', function(report) {
+      .on('delivery-report', function(err, report) {
+        t.ifError(err);
         t.ok(report !== undefined);
         t.ok(typeof report.topic === 'string');
         t.ok(typeof report.partition === 'number');
@@ -160,8 +163,9 @@ describe('Producer', function() {
      //'produce.offset.report': true
     });
     
-    producer.once('delivery-report', function(report) {
+    producer.once('delivery-report', function(err, report) {
       clearInterval(tt);
+      t.ifError(err);
       t.ok(report !== undefined);
       t.ok(typeof report.topic === 'string');
       t.ok(typeof report.partition === 'number');

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -31,7 +31,7 @@ util.inherits(Producer, Client);
  * the connection will by brought down by using poll, which automatically
  * runs when a transaction is made on the object.
  *
- * @param {object} conf - Key value pairs to configure the consumer
+ * @param {object} conf - Key value pairs to configure the producer
  * @param {object} topicConf - Key value pairs to create a default
  * topic configuration
  * @extends Client
@@ -56,13 +56,13 @@ function Producer(conf, topicConf) {
 
   var gTopic = conf.topic || false;
   var gPart = conf.partition || null;
-  var dr_cb = conf.dr_cb || null;
-  var dr_msg_cb = conf.dr_msg_cb || null;
-
+  var dr_cb = conf.dr_cb || conf.dr_msg_cb || null;
+  var dr_copy_payload = conf.dr_msg_cb || false;
+  
   // delete keys we don't want to pass on
   delete conf.topic;
   delete conf.partition;
-
+  
   delete conf.dr_cb;
   delete conf.dr_msg_cb;
 
@@ -77,24 +77,18 @@ function Producer(conf, topicConf) {
   this.defaultTopic = gTopic || null;
   this.defaultPartition = gPart == null ? -1 : gPart;
 
-  this.outstandingMessages = 0;
   this.sentMessages = 0;
 
   this.createdTopics = {};
 
-  if (dr_msg_cb) {
-    self.on('delivery-message-report', dr_msg_cb);
-  }
 
   if (dr_cb) {
     this._client.onDeliveryReport(function onDeliveryReport(err, report) {
       if (err) {
         self.emit('error', LibrdKafkaError.create(err));
-      } else {
-        self.outstandingMessages--;
-        self.emit('delivery-report', report);
       }
-    });
+      self.emit('delivery-report', err, report);
+    }, dr_copy_payload);
 
     if (typeof dr_cb === 'function') {
       self.on('delivery-report', dr_cb);
@@ -220,7 +214,6 @@ Producer.prototype.produce = function(topic, partition, message, key) {
     throw new TypeError('"topic" needs to be set');
   }
 
-  this.outstandingMessages++;
   this.sentMessages++;
 
   partition = partition == null ? this.defaultPartition : partition;

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -38,10 +38,15 @@ class Dispatcher {
   void Execute();
   void Activate();
   void Deactivate();
+
+  // if this flag is true, msg payload is added to the delivery report
+  bool dr_copy_payload = false;
+
  protected:
   std::vector<v8::Persistent<v8::Function, v8::CopyablePersistentTraits<v8::Function> > > callbacks;  // NOLINT
 
   uv_mutex_t async_lock;
+
  private:
   NAN_INLINE static NAUV_WORK_CB(AsyncMessage_) {
      Dispatcher *dispatcher =
@@ -96,8 +101,10 @@ struct delivery_report_t {
   int32_t partition;
   int64_t offset;
   std::string key;
+  size_t len;
+  void* payload;
 
-  explicit delivery_report_t(RdKafka::Message &);
+  explicit delivery_report_t(RdKafka::Message &, bool dr_copy_payload);
   ~delivery_report_t();
 };
 

--- a/src/producer.cc
+++ b/src/producer.cc
@@ -344,14 +344,17 @@ NAN_METHOD(Producer::NodeProduce) {
 NAN_METHOD(Producer::NodeOnDelivery) {
   Nan::HandleScope scope;
 
-  if (info.Length() < 1 || !info[0]->IsFunction()) {
+  if (info.Length() < 2 || !info[0]->IsFunction() || !info[1]->IsBoolean()) {
     // Just throw an exception
-    return Nan::ThrowError("Need to specify a callback");
+    return Nan::ThrowError("Need to specify a callback and a boolean");
   }
 
   Producer* producer = ObjectWrap::Unwrap<Producer>(info.This());
   v8::Local<v8::Function> cb = info[0].As<v8::Function>();
 
+  v8::Local<v8::Boolean> dr_copy_payload = info[1].As<v8::Boolean>();
+
+  producer->m_dr_cb.dispatcher.dr_copy_payload = dr_copy_payload->Value();
   producer->m_dr_cb.dispatcher.AddCallback(cb);
   info.GetReturnValue().Set(Nan::True());
 }


### PR DESCRIPTION
changed the delivery report callback API, inserted err argument before
report

dr_msg_cb configuration used as flag to copy or not the msg payload in
the delivery report

message payload not copied on the error path (see callbacks.cc TODO)

fixes #70 
committed for discussion, cleanup (eg public flag in Dispatcher TODO)

developed with @mimaison