### PR TITLE
Randomize the wait time in case the end of a partition was reached

### DIFF
--- a/lib/topic-readable.js
+++ b/lib/topic-readable.js
@@ -154,7 +154,7 @@ TopicReadable.prototype._read = function(size) {
       } else {
         setTimeout(function() {
           self._read(size);
-        }, self.waitInterval).unref();
+        }, self.waitInterval * Math.random()).unref();
       }
 
       return;

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -281,7 +281,9 @@ void ConsumerConsumeLoop::Execute(const ExecutionMessageBus& bus) {
       // EOF means there are no more messages to read.
       // We should wait a little bit for more messages to come in
       // when in consume loop mode
-      usleep(1000*1000);
+      // Randomise the wait time to avoid contention on different
+      // slow topics
+      usleep((int) (rand() * 1000 * 1000 / RAND_MAX));
     } else if (b.err() == RdKafka::ERR__TIMED_OUT) {
       // If it is timed out this could just mean there were no
       // new messages fetched quickly enough. This isn't really

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -283,7 +283,7 @@ void ConsumerConsumeLoop::Execute(const ExecutionMessageBus& bus) {
       // when in consume loop mode
       // Randomise the wait time to avoid contention on different
       // slow topics
-      usleep((int) (rand() * 1000 * 1000 / RAND_MAX));
+      usleep(static_cast<int>(rand_r() * 1000 * 1000 / RAND_MAX));
     } else if (b.err() == RdKafka::ERR__TIMED_OUT) {
       // If it is timed out this could just mean there were no
       // new messages fetched quickly enough. This isn't really

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -268,7 +268,8 @@ ConsumerConsumeLoop::ConsumerConsumeLoop(Nan::Callback *callback,
                                      const int & timeout_ms) :
   MessageWorker(callback),
   consumer(consumer),
-  m_timeout_ms(timeout_ms) {}
+  m_timeout_ms(timeout_ms),
+  m_rand_seed(time(NULL)) {}
 
 ConsumerConsumeLoop::~ConsumerConsumeLoop() {}
 
@@ -283,7 +284,7 @@ void ConsumerConsumeLoop::Execute(const ExecutionMessageBus& bus) {
       // when in consume loop mode
       // Randomise the wait time to avoid contention on different
       // slow topics
-      usleep(static_cast<int>(rand_r() * 1000 * 1000 / RAND_MAX));
+      usleep(static_cast<int>(rand_r(&m_rand_seed) * 1000 * 1000 / RAND_MAX));
     } else if (b.err() == RdKafka::ERR__TIMED_OUT) {
       // If it is timed out this could just mean there were no
       // new messages fetched quickly enough. This isn't really

--- a/src/workers.h
+++ b/src/workers.h
@@ -227,6 +227,7 @@ class ConsumerConsumeLoop : public MessageWorker {
  private:
   NodeKafka::Consumer * consumer;
   const int m_timeout_ms;
+  unsigned int m_rand_seed;
 };
 
 class ConsumerConsume : public ErrorAwareWorker {


### PR DESCRIPTION
Fixes #75 by randomising the wait interval, so for any timeout/topic activity values the contention never happens. At least it's not persistent.