### PR TITLE
Create topics with the topic config, not default config

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -111,7 +111,7 @@ function maybeTopic(name) {
     if (this.createdTopics[name]) {
       topic = this.createdTopics[name];
     } else {
-      topic = this.createdTopics[name] = this.Topic(name);
+      topic = this.createdTopics[name] = this.Topic(name, this.topicConfig);
     }
 
     return topic;

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -111,7 +111,7 @@ function maybeTopic(name) {
     if (this.createdTopics[name]) {
       topic = this.createdTopics[name];
     } else {
-      topic = this.createdTopics[name] = this.Topic(name, this.topicConfig);
+      topic = this.createdTopics[name] = this.Topic(name, this.topicConfig || undefined);
     }
 
     return topic;


### PR DESCRIPTION
For #68 

When providing just a topic name to the producer the new `Topic` object is created, but it doesn't honour the topic config supplied to the producer, but instead creates a `Topic` object with the default config. This default config then takes precedence over the custom config making the driver ignore the custom config.