### PR TITLE
Send undefined in to leverage default config for producer.

### DIFF
--- a/e2e/producer.spec.js
+++ b/e2e/producer.spec.js
@@ -97,7 +97,7 @@ describe('Producer', function() {
 
     producer.produce('test', null, new Buffer(''), '');
   });
-  
+
   it('should produce a message with a payload and key', function(done) {
     this.timeout(3000);
 
@@ -118,7 +118,7 @@ describe('Producer', function() {
 
     producer.produce('test', null, new Buffer('value'), 'key');
   });
-  
+
   it('should get 100% deliverability', function(done) {
     this.timeout(3000);
 
@@ -162,7 +162,7 @@ describe('Producer', function() {
      'request.required.acks': 1
      //'produce.offset.report': true
     });
-    
+
     producer.once('delivery-report', function(err, report) {
       clearInterval(tt);
       t.ifError(err);
@@ -176,5 +176,5 @@ describe('Producer', function() {
 
     producer.produce(topic, null, new Buffer('value'), 'key');
   });
-  
+
 });

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -58,11 +58,11 @@ function Producer(conf, topicConf) {
   var gPart = conf.partition || null;
   var dr_cb = conf.dr_cb || conf.dr_msg_cb || null;
   var dr_copy_payload = conf.dr_msg_cb || false;
-  
+
   // delete keys we don't want to pass on
   delete conf.topic;
   delete conf.partition;
-  
+
   delete conf.dr_cb;
   delete conf.dr_msg_cb;
 
@@ -111,7 +111,7 @@ function maybeTopic(name) {
     if (this.createdTopics[name]) {
       topic = this.createdTopics[name];
     } else {
-      topic = this.createdTopics[name] = this.Topic(name, {});
+      topic = this.createdTopics[name] = this.Topic(name);
     }
 
     return topic;
@@ -146,7 +146,7 @@ Producer.prototype.Topic = function(name, config) {
     if (!this._isConnected) {
       throw new Error('Producer not connected');
     }
-    return new Kafka.Topic(name, config, this._client);
+    return new Kafka.Topic(this._client, name, config || undefined);
   } catch (err) {
     err.message = 'Error creating topic "' + name + '"": ' + err.message;
     throw LibrdKafkaError.create(err);

--- a/src/connection.cc
+++ b/src/connection.cc
@@ -94,7 +94,7 @@ Baton Connection::CreateTopic(std::string topic_name, RdKafka::Conf* conf) {
   if (IsConnected()) {
     scoped_mutex_lock lock(m_connection_lock);
     if (IsConnected()) {
-    topic = RdKafka::Topic::create(m_client, topic_name, conf, errstr);
+      topic = RdKafka::Topic::create(m_client, topic_name, conf, errstr);
     } else {
       return Baton(RdKafka::ErrorCode::ERR__STATE);
     }


### PR DESCRIPTION
Previously the producer was sending in a `{}` object and always creating a config. This will check if the parameter is set and only make a topic config if it is.