### PR TITLE
Add missing rdstring.c to librdkafka.gyp

### DIFF
--- a/deps/librdkafka.gyp
+++ b/deps/librdkafka.gyp
@@ -161,6 +161,7 @@
         "librdkafka/src/rdaddr.c",
         "librdkafka/src/rdrand.c",
         "librdkafka/src/rdlist.c",
+        "librdkafka/src/rdstring.c",
         "librdkafka/src/tinycthread.c",
         "librdkafka/src/rdlog.c",
         "librdkafka/src/snappy.c"


### PR DESCRIPTION
When loading the latest native module based on the embedded deps/librdkafka, I get an error "symbol `rd_string_render` is missing". Turns out that `rdstring.c` (the file where `rd_string_render` is defined), is not included in the current node-gyp build script. This patch just adds the file.

Alternatively, the pull request https://github.com/Blizzard/node-rdkafka/pull/56 also adds it. But as long as it is not merged, it would be nice to have at least this patch merged.