### PR TITLE
Return error when Client.connect() fails

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -178,6 +178,12 @@ Client.prototype.connect = function(metadataOptions, cb) {
 
         next(err); return;
       }, 10000).unref();
+    } else {
+      if (emit) {
+        self.emit('error', LibrdKafkaError.create(err));
+      }
+
+      next(err);
     }
   };
 


### PR DESCRIPTION
I have the issue that when connecting to Kafka as a producer and somehow an error occurs during connect, no callback is called.

During investigation, I found the following issue:
In `Client.prototype.connect` the state `_isConnected` is set to `true` when no error occurred during connection - so far so good. But if an error occurs, the util method `fail` is called (https://github.com/Blizzard/node-rdkafka/blob/da94b6b210fa6fad31ac51beb03cb698f7dcb8d9/lib/client.js#L184-L189). But this method is doing nothing unless `_isConnected=true` (https://github.com/Blizzard/node-rdkafka/blob/da94b6b210fa6fad31ac51beb03cb698f7dcb8d9/lib/client.js#L154) and therefor the error will not be returned to the caller.

Tbh, not sure whether the provided patch is the best fix.