### PR TITLE
Fix Consumer committed() and position() API

### DIFF
--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -74,7 +74,7 @@ describe('Consumer/Producer', function() {
     });
   });
 
-  it('should be able to produce and consume messages: subscribe/consumeOnce', function(done) {
+  it('should be able to produce, consume messages, read position: subscribe/consumeOnce', function(done) {
     this.timeout(20000);
     var topic = 'test';
 
@@ -112,6 +112,12 @@ describe('Consumer/Producer', function() {
           t.equal(consumer.assignments().length > 0, true, 'Should have at least one assignment');
           t.equal(buffer.toString(), message.value.toString(),
             'message is not equal to buffer');
+          
+          // test consumer.position as we have consumed
+          var position = consumer.position();
+          t.equal(position.length, 1);
+          t.deepStrictEqual(position[0].partition, 0);
+          t.ok(position[0].offset >= 0);
           done();
         });
       };

--- a/e2e/consumer.spec.js
+++ b/e2e/consumer.spec.js
@@ -14,6 +14,7 @@ var eventListener = require('./listener');
 var KafkaConsumer = require('../').KafkaConsumer;
 
 var kafkaBrokerList = process.env.KAFKA_HOST || 'localhost:9092';
+var topic = 'test';
 
 describe('Consumer', function() {
   var gcfg;
@@ -27,7 +28,7 @@ describe('Consumer', function() {
     };
   });
 
-  describe('committed', function() {
+  describe('committed and position', function() {
 
     var consumer;
     beforeEach(function(done) {
@@ -47,25 +48,64 @@ describe('Consumer', function() {
       });
     });
 
-    it('should be able to get committed offsets', function(cb) {
+    it('before assign, committed offsets are empty', function(done) {
       consumer.committed(1000, function(err, committed) {
-        t.ifError(err);
         t.equal(Array.isArray(committed), true, 'Committed offsets should be an array');
-        for (var x in committed) {
-          var toppar = committed[x];
-          t.equal(typeof toppar, 'object', 'TopicPartition should be an object');
-          t.equal(typeof toppar.offset, 'number', 'Offset should be a number');
-        }
-        cb();
+        t.equal(committed.length, 0);
+        done();
       });
     });
 
-    it('should obey the timeout', function(cb) {
+    it('before assign, position returns an empty array', function() {
+      var position = consumer.position();
+      t.equal(Array.isArray(position), true, 'Position should be an array');
+      t.equal(position.length, 0);
+    });
+
+    it('after assign, should get committed array without offsets ', function(done) {
+      consumer.assign([{topic:topic, partition:0}]);
+      consumer.committed(1000, function(err, committed) {
+        t.ifError(err);
+        t.equal(committed.length, 1);
+        t.equal(typeof committed[0], 'object', 'TopicPartition should be an object');
+        t.deepStrictEqual(committed[0].partition, 0);
+        t.equal(committed[0].offset, undefined);
+        done();
+      });
+    });
+
+    it('after assign and commit, should get committed offsets', function(done) {
+      consumer.assign([{topic:topic, partition:0}]);
+      consumer.commitSync({topic:topic, partition:0, offset:1000})
+      consumer.committed(1000, function(err, committed) {
+        t.ifError(err);
+        t.equal(committed.length, 1);
+        t.equal(typeof committed[0], 'object', 'TopicPartition should be an object');
+        t.deepStrictEqual(committed[0].partition, 0);
+        t.deepStrictEqual(committed[0].offset, 1000);
+        done();
+      });
+    });
+
+    it('after assign, before consume, position should return an array without offsets', function(done) {
+      consumer.assign([{topic:topic, partition:0}]);
+      var position = consumer.position();
+      t.equal(Array.isArray(position), true, 'Position should be an array');
+      t.equal(position.length, 1);
+      t.equal(typeof position[0], 'object', 'TopicPartition should be an object');
+      t.deepStrictEqual(position[0].partition, 0);
+      t.equal(position[0].offset, undefined, 'before consuming, offset is undefined');
+      // see both.spec.js 'should be able to produce, consume messages, read position...'
+      // for checking of offset numeric value
+      done();
+    });
+
+    it('should obey the timeout', function(done) {
       consumer.committed(0, function(err, committed) {
         if (!err) {
           t.fail(err, 'not null', 'Error should be set for a timeout');
         }
-        cb();
+        done();
       });
     });
 
@@ -93,14 +133,14 @@ describe('Consumer', function() {
 
     it('should be able to subscribe', function() {
       t.equal(0, consumer.subscription().length);
-      consumer.subscribe(['test']);
+      consumer.subscribe([topic]);
       t.equal(1, consumer.subscription().length);
       t.equal('test', consumer.subscription()[0]);
       t.equal(0, consumer.assignments().length);
     });
 
     it('should be able to unsusbcribe', function() {
-      consumer.subscribe(['test']);
+      consumer.subscribe([topic]);
       t.equal(1, consumer.subscription().length);
       consumer.unsubscribe();
       t.equal(0, consumer.subscription().length);
@@ -130,14 +170,14 @@ describe('Consumer', function() {
 
     it('should be able to take an assignment', function() {
       t.equal(0, consumer.assignments().length);
-      consumer.assign([{ topic:'test', partition:0 }]);
+      consumer.assign([{ topic:topic, partition:0 }]);
       t.equal(1, consumer.assignments().length);
-      t.equal('test', consumer.assignments()[0].topic);
+      t.equal(topic, consumer.assignments()[0].topic);
       t.equal(0, consumer.subscription().length);
     });
 
     xit('should be able to take an empty assignment - EXCLUDED because of https://github.com/Blizzard/node-rdkafka/issues/63', function() {
-      consumer.assign([{ topic:'test', partition:0 }]);
+      consumer.assign([{ topic:topic, partition:0 }]);
       t.equal(1, consumer.assignments().length);
       consumer.assign([]);
       t.equal(0, consumer.assignments().length);
@@ -167,7 +207,7 @@ describe('Consumer', function() {
       consumer.connect({ timeout: 2000 }, function(err, info) {
         t.ifError(err);
 
-        consumer.subscribe(['test']);
+        consumer.subscribe([topic]);
 
         consumer.disconnect(function() {
           cb();
@@ -187,7 +227,7 @@ describe('Consumer', function() {
       consumer.connect({ timeout: 2000 }, function(err, info) {
         t.ifError(err);
 
-        consumer.subscribe(['test']);
+        consumer.subscribe([topic]);
 
         consumer.consume(function(err, message) {
           t.ifError(err);
@@ -209,7 +249,7 @@ describe('Consumer', function() {
       consumer.connect({ timeout: 2000 }, function(err, info) {
         t.ifError(err);
 
-        consumer.subscribe(['test']);
+        consumer.subscribe([topic]);
 
         consumer.consume(function(err, message) {
           t.notEqual(err, undefined, 'Error should not be undefined.');


### PR DESCRIPTION
The librdkafka c++ api required a vector filled with TopicPartitions. 
This is now passed after a refresh of assignments.

Added e2e tests

fixes #65 and #67

developed with @mimaison