### PR TITLE
Added support for opaques to correlated messages with delivery reports

### DIFF
--- a/e2e/producer.spec.js
+++ b/e2e/producer.spec.js
@@ -119,6 +119,28 @@ describe('Producer', function() {
     producer.produce('test', null, new Buffer('value'), 'key');
   });
 
+  it('should produce a message with an opaque', function(done) {
+    this.timeout(3000);
+
+    var tt = setInterval(function() {
+      producer.poll();
+    }, 200);
+
+    producer.once('delivery-report', function(err, report) {
+      clearInterval(tt);
+      t.ifError(err);
+      t.ok(report !== undefined);
+      t.ok(typeof report.topic === 'string');
+      t.ok(typeof report.partition === 'number');
+      t.ok(typeof report.offset === 'number');
+      t.equal(report.opaque, 'opaque');
+      done();
+    });
+
+    producer.produce('test', null, new Buffer('value'), null, 'opaque');
+  });
+
+
   it('should get 100% deliverability', function(done) {
     this.timeout(3000);
 

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -57,7 +57,6 @@ function Producer(conf, topicConf) {
   var gTopic = conf.topic || false;
   var gPart = conf.partition || null;
   var dr_cb = conf.dr_cb || conf.dr_msg_cb || null;
-  var dr_copy_payload = conf.dr_msg_cb || false;
 
   // delete keys we don't want to pass on
   delete conf.topic;
@@ -88,7 +87,7 @@ function Producer(conf, topicConf) {
         self.emit('error', LibrdKafkaError.create(err));
       }
       self.emit('delivery-report', err, report);
-    }, dr_copy_payload);
+    });
 
     if (typeof dr_cb === 'function') {
       self.on('delivery-report', dr_cb);
@@ -196,12 +195,13 @@ Producer.prototype._produceObject = util.deprecate(function(message, cb) {
  * @param {string} topic - The topic name to produce to.
  * @param {number|null} partition - The partition number to produce to.
  * @param {Buffer|null} message - The message to produce.
- * @param {string} [key] - The key associated with the message.
+ * @param {string} key - The key associated with the message.
+ * @param opaque - An object you want passed along with this message, if provided.
  * @throws {LibrdKafkaError} - Throws a librdkafka error if it failed.
  * @return {boolean} - returns an error if it failed, or true if not
  * @see Producer#produce
  */
-Producer.prototype.produce = function(topic, partition, message, key) {
+Producer.prototype.produce = function(topic, partition, message, key, opaque) {
   if (!this._isConnected) {
     throw new Error('Producer not connected');
   }
@@ -221,7 +221,7 @@ Producer.prototype.produce = function(topic, partition, message, key) {
   topic = maybeTopic.call(this, topic);
 
   return this._errorWrap(
-    this._client.produce(topic, partition, message, key || null));
+    this._client.produce(topic, partition, message, key || null, opaque || undefined));
 
 };
 

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -39,9 +39,6 @@ class Dispatcher {
   void Activate();
   void Deactivate();
 
-  // if this flag is true, msg payload is added to the delivery report
-  bool dr_copy_payload = false;
-
  protected:
   std::vector<v8::Persistent<v8::Function, v8::CopyablePersistentTraits<v8::Function> > > callbacks;  // NOLINT
 
@@ -102,9 +99,9 @@ struct delivery_report_t {
   int64_t offset;
   std::string key;
   size_t len;
-  void* payload;
+  void* opaque;
 
-  explicit delivery_report_t(RdKafka::Message &, bool dr_copy_payload);
+  explicit delivery_report_t(RdKafka::Message &);
   ~delivery_report_t();
 };
 

--- a/src/producer.h
+++ b/src/producer.h
@@ -58,8 +58,7 @@ class Producer : public Connection {
   Baton Flush(int timeout_ms);
   #endif
 
-  Baton Produce(ProducerMessage* msg);
-  Baton Produce(void*, size_t, RdKafka::Topic*, int32_t, std::string*);
+  Baton Produce(void*, size_t, RdKafka::Topic*, int32_t, std::string*, void*);
   std::string Name();
 
   void ActivateDispatchers();


### PR DESCRIPTION
This commit adds support for using opaques outside of c++ land. You can pass it arbitrary javascript objects that then can be used to correlate your message across its lifecycle.

For example:

```js
producer.produce(topic, partition, message, key, { messageId: 20 });

producer.on('delivery-report', function(err, report) {
   if (err) {
      return console.error(err);
   }

   if (report.opaque && report.opaque.messageId === 20) {
      // We got our message that we sent above.
   }
});
```

This allows us to get away from needing to do string/buffer comparison to potentially large payloads, and instead use a predictable, consistent way of identifying messages across delivery reports.