### PR TITLE
WIP For discussion - Issue #93 when conf.rebalance_cb is set to true

### DIFF
--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -50,10 +50,16 @@ function KafkaConsumer(conf, topicConf) {
       // Emit the event
       self.emit('rebalance', e);
       // That's it
-      if (e.code === 500 /*CODES.REBALANCE.PARTITION_ASSIGNMENT*/) {
-        self.assign(e.assignment);
-      } else if (e.code === 501 /*CODES.REBALANCE.PARTITION_UNASSIGNMENT*/) {
-        self.unassign();
+      try {
+        if (self.isConnected()) {
+          if (e.code === 500 /*CODES.REBALANCE.PARTITION_ASSIGNMENT*/) {
+            self.assign(e.assignment);
+          } else if (e.code === 501 /*CODES.REBALANCE.PARTITION_UNASSIGNMENT*/) {
+            self.unassign();
+          }
+        }
+      } catch (err) {
+        console.log(err);
       }
     };
   } else if (onRebalance && typeof onRebalance === 'function') {


### PR DESCRIPTION
consumer.disconnect() causes the self.unassign() in the rebalance
function to be invoked when the consumer is in the wrong state.

the test `should emit events with conf.rebalance_cb=true`
passes but the testsuite hangs (process does not exit)