### PR TITLE
Change topics to be destroyed on use, or take a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ var producer = new Kafka.Producer({
 });
 ```
 
-A `Producer` requires only `metadata.broker.list` (the Kafka brokers) to be created.  The values in this list are separated by commas.  For other configuration options, see the [Configuration.md](https://github.com/edenhill/librdkafka/blob/0.9.3.x/CONFIGURATION.md) file described previously. 
+A `Producer` requires only `metadata.broker.list` (the Kafka brokers) to be created.  The values in this list are separated by commas.  For other configuration options, see the [Configuration.md](https://github.com/edenhill/librdkafka/blob/0.9.3.x/CONFIGURATION.md) file described previously.
 
 The following example illustrates a list with several `librdkafka` options set.
 
@@ -174,6 +174,11 @@ producer.on('ready', function() {
       new Buffer('Awesome message'),
       // for keyed messages, we also specify the key - note that this field is optional
       'Stormwind',
+      // you can send a timestamp here. If your broker version supports it,
+      // it will get added. Otherwise, we default to 0
+      Date.now(),
+      // you can send an opaque token here, which gets passed along
+      // to your delivery reports
     );
   } catch (err) {
     console.error('A problem occurred when sending our message');

--- a/e2e/producer.spec.js
+++ b/e2e/producer.spec.js
@@ -119,7 +119,7 @@ describe('Producer', function() {
         done();
       });
 
-      producer.produce('test', null, new Buffer('value'), null, 'opaque');
+      producer.produce('test', null, new Buffer('value'), null, null, 'opaque');
     });
 
 

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -110,7 +110,7 @@ function maybeTopic(name) {
     if (this.createdTopics[name]) {
       topic = this.createdTopics[name];
     } else {
-      topic = this.createdTopics[name] = this.Topic(name, this.topicConfig || undefined);
+      topic = name;
     }
 
     return topic;
@@ -142,10 +142,7 @@ function maybeTopic(name) {
  */
 Producer.prototype.Topic = function(name, config) {
   try {
-    if (!this._isConnected) {
-      throw new Error('Producer not connected');
-    }
-    return new Kafka.Topic(this._client, name, config || undefined);
+    return new Kafka.Topic(name, config || undefined);
   } catch (err) {
     err.message = 'Error creating topic "' + name + '"": ' + err.message;
     throw LibrdKafkaError.create(err);
@@ -201,7 +198,7 @@ Producer.prototype._produceObject = util.deprecate(function(message, cb) {
  * @return {boolean} - returns an error if it failed, or true if not
  * @see Producer#produce
  */
-Producer.prototype.produce = function(topic, partition, message, key, opaque) {
+Producer.prototype.produce = function(topic, partition, message, key, timestamp, opaque) {
   if (!this._isConnected) {
     throw new Error('Producer not connected');
   }
@@ -220,8 +217,18 @@ Producer.prototype.produce = function(topic, partition, message, key, opaque) {
 
   topic = maybeTopic.call(this, topic);
 
+  // Okay... really quick
+  // We do not support using a timestamp if topic is an object. I know, it's
+  // weird.
+  // https://github.com/edenhill/librdkafka/blob/master/src-cpp/rdkafkacpp.h#L1891
+  // So... let's let the user know
+
+  if (typeof topic !== 'string' && timestamp) {
+    throw new TypeError('"topic" must be a string to use the 0.10 timestamp feature');
+  }
+
   return this._errorWrap(
-    this._client.produce(topic, partition, message, key, opaque));
+    this._client.produce(topic, partition, message, key, timestamp, opaque));
 
 };
 

--- a/src/producer.h
+++ b/src/producer.h
@@ -59,6 +59,7 @@ class Producer : public Connection {
   #endif
 
   Baton Produce(void*, size_t, RdKafka::Topic*, int32_t, std::string*, void*);
+  Baton Produce(void*, size_t, std::string, int32_t, std::string*, int64_t, void*);  // NOLINT
   std::string Name();
 
   void ActivateDispatchers();

--- a/src/topic.h
+++ b/src/topic.h
@@ -24,7 +24,7 @@ class Topic : public Nan::ObjectWrap {
   static void Init(v8::Local<v8::Object>);
   static v8::Local<v8::Object> NewInstance(v8::Local<v8::Value> arg);
 
-  RdKafka::Topic * toRDKafkaTopic();
+  Baton toRDKafkaTopic(Connection *handle);
 
  protected:
   static Nan::Persistent<v8::Function> constructor;
@@ -32,15 +32,17 @@ class Topic : public Nan::ObjectWrap {
 
   static NAN_METHOD(NodeGetMetadata);
 
-  RdKafka::Topic * m_topic;
   // TopicConfig * config_;
 
   std::string errstr;
   std::string name();
 
  private:
-  Topic(std::string, RdKafka::Conf *, Connection *);
+  Topic(std::string, RdKafka::Conf *);
   ~Topic();
+
+  std::string m_topic_name;
+  RdKafka::Conf * m_config;
 
   static NAN_METHOD(NodeGetName);
   static NAN_METHOD(NodePartitionAvailable);


### PR DESCRIPTION
This is an unfortunate solution to a potentially infrequent problem. 

When topic objects are created, they are kept in a map in the JavaScript producer object (essentially establishing handles in v8). When a producer is disconnected from, and then reconnected to, it will try to use the  existing topic handles in the map. However, topics are bound to `RdKafka::Handle`, which is destroyed on disconnect. 

We could make it clear the cache of created topics on disconnect, but that means disconnect is now going to wait on the garbage collector to remove the topics before the handle will release. We definitely don't want to block that long, or potentially forever, because we are relying on the GC.

We can make hooks between both objects - topic and handle - so they can be notified of changes. However, this requires tracking that I think is overly complicated for this issue.

This change makes it so for most use cases, where strings are provided, there should be about a 0 change in performance. However, for cases where topic configs are passed in, the topic is made and destroyed per produce. This is a 20% performance decrease, generally, in small message cases where a topic config is used for each produce. 

I elected to do it this way because in cases where you are using the same config per produce, you should probably use the default topic config parameter anyway. In cases where the config is varied per message, and performance is very important, you could make multiple producers. And in the case where you are using dynamic topic names, you would probably be creating a new topic for many of the calls anyway.

With that considered, and knowing that the library is going in the direction of taking a string instead of a topic object anyway, I think this change is overall good for the stability of the library.
