### PR TITLE
Closing the TopicReadable calls the callback

### DIFF
--- a/lib/topic-readable.js
+++ b/lib/topic-readable.js
@@ -209,6 +209,6 @@ TopicReadable.prototype.close = function(cb) {
     if (!self.unsubscribed) {
       self.consumer.unsubscribe();
     }
-    self.emit('closed');
+    self.emit('close');
   }
 };

--- a/test/topic-readable.spec.js
+++ b/test/topic-readable.spec.js
@@ -159,8 +159,16 @@ module.exports = {
       stream.on('end', function() {
         next();
       });
-    }
+    },
 
+    'calls the callback on close': function (next) {
 
-  },
+      fakeClient.unsubscribe = function () {};
+      var stream = new TopicReadable(fakeClient, 'topic');
+      stream.once('readable', function () {
+        stream.close(next);
+      });
+
+    },
+  }
 };


### PR DESCRIPTION
The callback is called on the `'close'` event – while the code emitted a `'closed'` one. I chose to stick with the former one, as it is what standard readables emit.