### PR TITLE
commitSync throws errors as they happen

### DIFF
--- a/e2e/consumer.spec.js
+++ b/e2e/consumer.spec.js
@@ -28,6 +28,36 @@ describe('Consumer', function() {
     };
   });
 
+  describe('commit and commitSync', function() {
+    var consumer;
+    beforeEach(function(done) {
+      consumer = new KafkaConsumer(gcfg, {});
+
+      consumer.connect({ timeout: 2000 }, function(err, info) {
+        t.ifError(err);
+        done();
+      });
+
+      eventListener(consumer);
+    });
+
+    afterEach(function(done) {
+      consumer.disconnect(function() {
+        done();
+      });
+    });
+
+    it('commitSync throws an error when answered with one', function() {
+      t.throws(function () {
+        consumer.commitSync({
+          offset: -10000, topic:topic, partition: 0
+        });
+      });
+    });
+
+  });
+
+
   describe('committed and position', function() {
 
     var consumer;

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -490,11 +490,18 @@ KafkaConsumer.prototype.commitMessage = function(msg, cb) {
  * @return {KafkaConsumer} - returns itself.
  */
 KafkaConsumer.prototype.commitSync = function(topicPartition) {
+  var output;
   if (topicPartition) {
-    return this._client.commitSync(topicPartition);
+    output = this._client.commitSync(topicPartition);
   } else {
-    return this._client.commitSync();
+    output = this._client.commitSync();
   }
+
+  if (output && output.code !== LibrdKafkaError.codes.ERR_NO_ERROR) {
+    throw new LibrdKafkaError(output);
+  }
+
+  return this;
 };
 
 /**
@@ -515,5 +522,11 @@ KafkaConsumer.prototype.commitMessageSync = function(msg) {
     offset: msg.offset + 1
   };
 
-  return this._client.commitSync(toppar);
+  var output = this._client.commitSync(toppar);
+
+  if (output && output.code !== LibrdKafkaError.codes.ERR_NO_ERROR) {
+    throw new LibrdKafkaError(output);
+  }
+
+  return this;
 };


### PR DESCRIPTION
It used to return error objects instead.

This seems to me the better API – but might be breaking some code. Personally I was surprised by this behavior and had a bug that assumed that because the commitSync did not throw.

@webmakersteve there are a couple of other issues with commit / commitSync that I want to look at / work on, would you prefer separate PRs?