### PR TITLE
Tests for commit behavior

### DIFF
--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -247,7 +247,7 @@ describe('Consumer/Producer', function() {
       });
     });
 
-    it.only('should async commit after consuming', function(done) {
+    it('should async commit after consuming', function(done) {
       this.timeout(20000);
       var key = '';
       var value = new Buffer('');
@@ -274,6 +274,42 @@ describe('Consumer/Producer', function() {
                 done();
               }, 10000);
             });
+          });
+        });
+      });
+      consumer.subscribe([topic]);
+      consumer.consume();
+
+      setTimeout(function() {
+        producer.produce(topic, null, value, key);
+      }, 2000);
+    });
+    it('should synchronous commit after consuming', function(done) {
+      this.timeout(20000);
+      var key = '';
+      var value = new Buffer('');
+
+      var lastOffset = null;
+      consumer.once('data', function(message) {
+        lastOffset = message.offset;
+        consumer.commitSync(message);
+        consumer.disconnect(function() {
+          consumer.connect({}, function(err, d) {
+            t.ifError(err);
+            t.equal(typeof d, 'object', 'metadata should be returned');
+
+            consumer.once('data', function(message) {
+              console.log('First message offset:', lastOffset, 'New message',
+                'offset:', message.offset);
+              done(new Error('Should never be here'));
+            });
+
+            consumer.subscribe([topic]);
+            consumer.consume();
+
+            setTimeout(function() {
+              done();
+            }, 10000);
           });
         });
       });

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -255,7 +255,7 @@ describe('Consumer/Producer', function() {
       var lastOffset = null;
       consumer.once('data', function(message) {
         lastOffset = message.offset;
-        consumer.commit(message, function(err) {
+        consumer.commitMessage(message, function(err) {
           consumer.disconnect(function() {
             consumer.connect({}, function(err, d) {
               t.ifError(err);
@@ -272,7 +272,7 @@ describe('Consumer/Producer', function() {
 
               setTimeout(function() {
                 done();
-              }, 10000);
+              }, 5000);
             });
           });
         });
@@ -292,7 +292,7 @@ describe('Consumer/Producer', function() {
       var lastOffset = null;
       consumer.once('data', function(message) {
         lastOffset = message.offset;
-        consumer.commitSync(message);
+        consumer.commitMessageSync(message);
         consumer.disconnect(function() {
           consumer.connect({}, function(err, d) {
             t.ifError(err);
@@ -309,7 +309,7 @@ describe('Consumer/Producer', function() {
 
             setTimeout(function() {
               done();
-            }, 10000);
+            }, 5000);
           });
         });
       });

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -215,4 +215,74 @@ describe('Consumer/Producer', function() {
     }, 2000);
   });
 
+  describe('Exceptional cases', function() {
+    var grp = 'kafka-mocha-grp-' + crypto.randomBytes(20).toString('hex');
+    var consumerOpts = {
+      'metadata.broker.list': kafkaBrokerList,
+      'group.id': grp,
+      'fetch.wait.max.ms': 1000,
+      'session.timeout.ms': 10000,
+      'enable.auto.commit': false,
+      'debug': 'all'
+      // paused: true,
+    };
+
+    beforeEach(function(done) {
+      consumer = new Kafka.KafkaConsumer(consumerOpts, {
+        'auto.offset.reset': 'largest',
+      });
+
+      consumer.connect({}, function(err, d) {
+        t.ifError(err);
+        t.equal(typeof d, 'object', 'metadata should be returned');
+        done();
+      });
+
+      eventListener(consumer);
+    });
+
+    afterEach(function(done) {
+      consumer.disconnect(function() {
+        done();
+      });
+    });
+
+    it.only('should async commit after consuming', function(done) {
+      this.timeout(20000);
+      var key = '';
+      var value = new Buffer('');
+
+      var lastOffset = null;
+      consumer.once('data', function(message) {
+        lastOffset = message.offset;
+        consumer.commit(message, function(err) {
+          consumer.disconnect(function() {
+            consumer.connect({}, function(err, d) {
+              t.ifError(err);
+              t.equal(typeof d, 'object', 'metadata should be returned');
+
+              consumer.once('data', function(message) {
+                console.log('First message offset:', lastOffset, 'New message',
+                  'offset:', message.offset);
+                done(new Error('Should never be here'));
+              });
+
+              consumer.subscribe([topic]);
+              consumer.consume();
+
+              setTimeout(function() {
+                done();
+              }, 10000);
+            });
+          });
+        });
+      });
+      consumer.subscribe([topic]);
+      consumer.consume();
+
+      setTimeout(function() {
+        producer.produce(topic, null, value, key);
+      }, 2000);
+    });
+  });
 });

--- a/e2e/consumer.spec.js
+++ b/e2e/consumer.spec.js
@@ -89,24 +89,6 @@ describe('Consumer', function() {
         done();
       });
     });
-    it('should async commit after consuming', function(done) {
-      consumer.subscribe([topic]);
-      consumer.consume(1, function(err, messages) {
-        consumer.commit(messages[0], function(err) {
-          t.ifError(err);
-          consumer.committed(1000, function(err, committed) {
-            t.ifError(err);
-            t.equal(committed.length, 1);
-            t.equal(typeof committed[0], 'object', 'TopicPartition should be an object');
-            t.deepStrictEqual(committed[0].partition, 0);
-            t.deepStrictEqual(committed[0].offset, 1000);
-            consumer.disconnect(function() {
-              done();
-            });
-          });
-        });
-      });
-    });
     xit('after assign, before consume, position should return an array without offsets (Timing out issue in this situation, so pending)', function(done) {
       consumer.assign([{topic:topic, partition:0}]);
       var position = consumer.position();

--- a/e2e/consumer.spec.js
+++ b/e2e/consumer.spec.js
@@ -89,7 +89,24 @@ describe('Consumer', function() {
         done();
       });
     });
-
+    it('should async commit after consuming', function(done) {
+      consumer.subscribe([topic]);
+      consumer.consume(1, function(err, messages) {
+        consumer.commit(messages[0], function(err) {
+          t.ifError(err);
+          consumer.committed(1000, function(err, committed) {
+            t.ifError(err);
+            t.equal(committed.length, 1);
+            t.equal(typeof committed[0], 'object', 'TopicPartition should be an object');
+            t.deepStrictEqual(committed[0].partition, 0);
+            t.deepStrictEqual(committed[0].offset, 1000);
+            consumer.disconnect(function() {
+              done();
+            });
+          });
+        });
+      });
+    });
     xit('after assign, before consume, position should return an array without offsets (Timing out issue in this situation, so pending)', function(done) {
       consumer.assign([{topic:topic, partition:0}]);
       var position = consumer.position();
@@ -265,9 +282,6 @@ describe('Consumer', function() {
         });
 
       });
-
     });
-
   });
-
 });


### PR DESCRIPTION
Resubmitting this to add the commit tests. I am afraid they will not play nice with other tests as they leave a `consumer.once()` untriggered... if you think that's ok let me know.

I'll push the changes to meet the new API for commitMessage() in a few