### PR TITLE
Remove error event from non-stream implementations

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -66,7 +66,7 @@ function Client(globalConf, SubClientType, topicConf) {
     this._client.onEvent(function eventHandler(eventType, eventData) {
       switch (eventType) {
         case 'error':
-          self.emit('error', LibrdKafkaError.create(eventData));
+          self.emit('event.error', LibrdKafkaError.create(eventData));
           break;
         case 'stats':
           self.emit('event.stats', eventData);
@@ -147,7 +147,7 @@ Client.prototype.connect = function(metadataOptions, cb) {
 
   this._isConnecting = true;
 
-  var fail = function(err, emit) {
+  var fail = function(err) {
     var callbackCalled = false;
     var t;
 
@@ -159,9 +159,6 @@ Client.prototype.connect = function(metadataOptions, cb) {
         }
         clearTimeout(t);
         callbackCalled = true;
-        if (emit) {
-          self.emit('error', LibrdKafkaError.create(err));
-        }
 
         next(err); return;
       });
@@ -172,16 +169,10 @@ Client.prototype.connect = function(metadataOptions, cb) {
           return;
         }
         callbackCalled = true;
-        if (emit) {
-          self.emit('error', LibrdKafkaError.create(err));
-        }
 
         next(err); return;
       }, 10000).unref();
     } else {
-      if (emit) {
-        self.emit('error', LibrdKafkaError.create(err));
-      }
 
       next(err);
     }
@@ -189,7 +180,7 @@ Client.prototype.connect = function(metadataOptions, cb) {
 
   this._client.connect(function(err, info) {
     if (err) {
-      fail(err, true); return;
+      fail(LibrdKafkaError.create(err)); return;
     }
 
     self._isConnected = true;
@@ -337,9 +328,8 @@ Client.prototype.getMetadata = function(metadataOptions, cb) {
 
   this._client.getMetadata(metadataOptions || {}, function(err, metadata) {
     if (err) {
-      self.emit('error', LibrdKafkaError.create(err));
       if (cb) {
-        cb(err);
+        cb(LibrdKafkaError.create(err));
       }
       return;
     }
@@ -379,7 +369,6 @@ Client.prototype._errorWrap = function(errorCode, intIsError) {
 
   if (errorCode !== LibrdKafkaError.codes.ERR_NO_ERROR) {
     var e = LibrdKafkaError.create(errorCode);
-    this.emit('error', e);
     throw e;
   }
 

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -138,8 +138,8 @@ KafkaConsumer.prototype.committed = function(timeout, cb) {
   var self = this;
   this._client.committed(timeout, function(err, topicPartitions) {
     if (err) {
-      self.emit('error', err);
-      cb(err); return;
+      cb(LibrdKafkaError.create(err));
+      return;
     }
 
     cb(null, topicPartitions);
@@ -320,7 +320,6 @@ KafkaConsumer.prototype._consumeLoop = function(timeoutMs, cb) {
       err = new LibrdKafkaError(err);
       if (err.code !== LibrdKafkaError.codes.ERR__TIMED_OUT &&
           err.code !== LibrdKafkaError.codes.ERR__PARTITION_EOF) {
-        self.emit('error', err);
       }
       cb(err);
     } else {
@@ -348,38 +347,25 @@ KafkaConsumer.prototype._consumeLoop = function(timeoutMs, cb) {
 KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, cb) {
   var self = this;
 
-  try {
-    this._client.consume(timeoutMs, numMessages, function(err, messages) {
-      if (err) {
-        err = new LibrdKafkaError(err);
-        if (cb) {
-          cb(err);
-        }
-        self.emit('error', err);
-        return;
-      }
-
-      for (var i = 0; i < messages.length; i++) {
-        self.emit('data', messages[i]);
-      }
-
+  this._client.consume(timeoutMs, numMessages, function(err, messages) {
+    if (err) {
+      err = new LibrdKafkaError(err);
       if (cb) {
-        cb(null, messages);
+        cb(err);
       }
+      return;
+    }
 
-    });
-  } catch (e) {
-    // This either means we are disconnected, or we were never subscribed.
-    // This is basically non-recoverable.
-    var error = new LibrdKafkaError(e);
-    self.emit('error', error);
+    for (var i = 0; i < messages.length; i++) {
+      self.emit('data', messages[i]);
+    }
 
     if (cb) {
-      setImmediate(function() {
-        cb(error);
-      });
+      cb(null, messages);
     }
-  }
+
+  });
+
 };
 
 /**

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -86,7 +86,7 @@ function Producer(conf, topicConf) {
   if (dr_msg_cb || dr_cb) {
     this._client.onDeliveryReport(function onDeliveryReport(err, report) {
       if (err) {
-        self.emit('error', LibrdKafkaError.create(err));
+        err = LibrdKafkaError.create(err);
       }
       self.emit('delivery-report', err, report);
     }, !!dr_msg_cb);


### PR DESCRIPTION
Error event is unnecessary as callbacks will pass the error forward. If the user does not care about the error, they would not specify the callback.

An error event should be saved for fatal type errors that `librdkafka` would not recover from ordinarily. There are essentially none of these situations currently (as far as I know).