### PR TITLE
Refactor async commit to use internal async method

### DIFF
--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -242,6 +242,7 @@ describe('Consumer/Producer', function() {
     });
 
     afterEach(function(done) {
+      this.timeout(10000);
       consumer.disconnect(function() {
         done();
       });
@@ -253,46 +254,11 @@ describe('Consumer/Producer', function() {
       var value = new Buffer('');
 
       var lastOffset = null;
+
       consumer.once('data', function(message) {
         lastOffset = message.offset;
-        consumer.commitMessage(message, function(err) {
-          consumer.disconnect(function() {
-            consumer.connect({}, function(err, d) {
-              t.ifError(err);
-              t.equal(typeof d, 'object', 'metadata should be returned');
+        consumer.commitMessage(message);
 
-              consumer.once('data', function(message) {
-                console.log('First message offset:', lastOffset, 'New message',
-                  'offset:', message.offset);
-                done(new Error('Should never be here'));
-              });
-
-              consumer.subscribe([topic]);
-              consumer.consume();
-
-              setTimeout(function() {
-                done();
-              }, 5000);
-            });
-          });
-        });
-      });
-      consumer.subscribe([topic]);
-      consumer.consume();
-
-      setTimeout(function() {
-        producer.produce(topic, null, value, key);
-      }, 2000);
-    });
-    it('should synchronous commit after consuming', function(done) {
-      this.timeout(20000);
-      var key = '';
-      var value = new Buffer('');
-
-      var lastOffset = null;
-      consumer.once('data', function(message) {
-        lastOffset = message.offset;
-        consumer.commitMessageSync(message);
         consumer.disconnect(function() {
           consumer.connect({}, function(err, d) {
             t.ifError(err);
@@ -313,6 +279,7 @@ describe('Consumer/Producer', function() {
           });
         });
       });
+
       consumer.subscribe([topic]);
       consumer.consume();
 
@@ -320,5 +287,6 @@ describe('Consumer/Producer', function() {
         producer.produce(topic, null, value, key);
       }, 2000);
     });
+
   });
 });

--- a/e2e/consumer.spec.js
+++ b/e2e/consumer.spec.js
@@ -28,7 +28,7 @@ describe('Consumer', function() {
     };
   });
 
-  describe('commit and commitSync', function() {
+  describe('commit', function() {
     var consumer;
     beforeEach(function(done) {
       consumer = new KafkaConsumer(gcfg, {});
@@ -44,14 +44,6 @@ describe('Consumer', function() {
     afterEach(function(done) {
       consumer.disconnect(function() {
         done();
-      });
-    });
-
-    it('commitSync throws an error when answered with one', function() {
-      t.throws(function () {
-        consumer.commitSync({
-          offset: -10000, topic:topic, partition: 0
-        });
       });
     });
 

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -369,24 +369,6 @@ KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, cb) {
 };
 
 /**
- * Subscribe to an array of topics.
- * @param  {array} topics - An array of topics to subscribe to.
- * @return {KafkaConsumer} - Returns itself
- * @deprecated
- */
-KafkaConsumer.prototype.subscribeSync = util.deprecate(KafkaConsumer.prototype.consume,
-  'subscribeSync: use subscribe instead');
-
-  /**
-   * @param  {KafkaConsumer~readCallback} cb - Callback to return when the work is
-   * done
-   * @return {KafkaConsumer} - Returns itself
-   * @deprecated
-   */
-KafkaConsumer.prototype.read = util.deprecate(KafkaConsumer.prototype.consume,
-  'this.read: use this.consume instead');
-
-/**
  * This callback returns the message read from Kafka.
  *
  * @callback KafkaConsumer~readCallback
@@ -401,31 +383,14 @@ KafkaConsumer.prototype.read = util.deprecate(KafkaConsumer.prototype.consume,
  * If you provide a topic partition, it will commit that. Otherwise,
  * it will commit all read offsets for all topic partitions.
  *
- * @param {object|function} - Topic partition object to commit or callback
- * if you are committing all topic partitions.
- * @param {function} - Callback to fire when committing is done.
+ * @param {object|null} - Topic partition object to commit, or null if you
+ * are going to commit all read offsets.
+ * @throws
  *
  * @return {KafkaConsumer} - returns itself.
  */
-KafkaConsumer.prototype.commit = function() {
-  var cb;
-  var toppar = null;
-
-  if (arguments.length === 0) {
-    cb = function() {};
-  } else if (arguments.length === 1) {
-    cb = arguments[0];
-    if (typeof cb !== 'function') {
-      toppar = cb;
-      cb = function() {};
-    }
-  } else if (arguments.length === 2) {
-    toppar = arguments[0];
-    cb = arguments[1];
-  }
-
-  this._client.commit(toppar, cb);
-
+KafkaConsumer.prototype.commit = function(topicPartition) {
+  this._errorWrap(this._client.commit(topicPartition), true);
   return this;
 };
 
@@ -438,56 +403,52 @@ KafkaConsumer.prototype.commit = function() {
  * This is basically a convenience method to map commit properly. We need to
  * add one to the offset in this case
  *
- * @param {object|function} - Message object to commit or callback
+ * @param {object} - Message object to commit or callback
  * if you are committing all messages
- * @param {function} - Callback to fire when committing is done.
+ * @throws
  *
  * @return {KafkaConsumer} - returns itself.
  */
-KafkaConsumer.prototype.commitMessage = function(msg, cb) {
-  var toppar = {
+KafkaConsumer.prototype.commitMessage = function(msg) {
+  var topicPartition = {
     topic: msg.topic,
     partition: msg.partition,
     offset: msg.offset + 1
   };
 
-  return this._client.commit(toppar, cb);
+  return this._client.commit(topicPartition);
 };
 
 /**
  * Commit a topic partition (or all topic partitions) synchronously
  *
- * Commit topic partitions with our without offsets to Kafka so they will not be
- * read by other clients.
+ * @param {object|null} - Topic partition object to commit, or null if you
+ * are going to commit all read offsets.
+ * @throws
  *
- * @see KafkaConsumer#commitSync
- * @param  {object} msg - A topic partition object to commit. If none
- * is provided, we will commit all read topic partition offsets.
  * @return {KafkaConsumer} - returns itself.
  */
 KafkaConsumer.prototype.commitSync = function(topicPartition) {
   this._errorWrap(this._client.commitSync(topicPartition), true);
-
   return this;
-};
+}
 
 /**
  * Commit a message (or all messages) synchronously
  *
- * Commit a message to Kafka so it, and messages after it, will not be
- * ready by Kafka
- *
  * @see KafkaConsumer#commitMessageSync
  * @param  {object} msg - A message object to commit. If none
  * is provided, we will commit all read offsets.
+ * @throws
+ *
  * @return {KafkaConsumer} - returns itself.
  */
 KafkaConsumer.prototype.commitMessageSync = function(msg) {
-  var toppar = {
+  var topicPartition = {
     topic: msg.topic,
     partition: msg.partition,
     offset: msg.offset + 1
   };
 
-  return this._client.commitSync(toppar);
+  return this._client.commitSync(topicPartition);
 };

--- a/src/consumer.h
+++ b/src/consumer.h
@@ -24,15 +24,6 @@
 
 namespace NodeKafka {
 
-struct consumer_commit_t {
-  int64_t m_offset;
-  int m_partition;
-  std::string m_topic_name;
-
-  consumer_commit_t(std::string, int, int64_t);
-  consumer_commit_t();
-};
-
 
 /**
  * @brief Consumer v8 wrapped object.
@@ -56,8 +47,14 @@ class Consumer : public Connection {
   Baton Unsubscribe();
   bool IsSubscribed();
 
+  // Asynchronous commit events
   Baton Commit(std::string, int, int64_t);
   Baton Commit();
+
+  // Synchronous commit events
+  Baton CommitSync(std::string, int, int64_t);
+  Baton CommitSync();
+
   Baton Committed(int timeout_ms);
   Baton Position();
 

--- a/src/workers.h
+++ b/src/workers.h
@@ -273,23 +273,6 @@ class ConsumerConsumeNum : public ErrorAwareWorker {
   std::vector<RdKafka::Message*> m_messages;
 };
 
-class ConsumerCommit : public ErrorAwareWorker {
- public:
-  ConsumerCommit(
-    Nan::Callback*, NodeKafka::Consumer*);
-  ConsumerCommit(
-    Nan::Callback*, NodeKafka::Consumer*, consumer_commit_t);
-  ~ConsumerCommit();
-
-  void Execute();
-  void HandleOKCallback();
-  void HandleErrorCallback();
- private:
-  NodeKafka::Consumer * consumer;
-  consumer_commit_t m_conf;
-  bool committing_message;
-};
-
 }  // namespace Workers
 
 }  // namespace NodeKafka

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,1 @@
 --ui exports
---no-colors


### PR DESCRIPTION
Previously it used a v8 worker to spin up and do the commit, but the refactor has it use the async method provided in the library. It currently does not take a callback.

Synchronous methods are still available and behave as they did previously.