### PR TITLE
Refactor configure step for compilation

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,8 +1,8 @@
 {
   "variables": {
       # may be redefined in command line on configuration stage
-      # "build_librdkafka%": "<!(echo ${BUILD_LIBRDKAFKA:-1})"
-      "build_librdkafka%": "1"
+      # "BUILD_LIBRDKAFKA%": "<!(echo ${BUILD_LIBRDKAFKA:-1})"
+      "BUILD_LIBRDKAFKA%": "<!(node ./util/get-env.js BUILD_LIBRDKAFKA 1)"
   },
   "targets": [
     {
@@ -51,7 +51,7 @@
           },
           {
             'conditions': [
-              [ "<(build_librdkafka)==1",
+              [ "<(BUILD_LIBRDKAFKA)==1",
                 {
                   "dependencies": [
                       "<(module_root_dir)/deps/librdkafka.gyp:librdkafkacpp"

--- a/configure
+++ b/configure
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# This file is intended to be run on unix systems to configure librdkafka
+# inside the submodules
+
+# This does not get run on windows which uses the build in solutions file
+
+pushd ./deps/librdkafka &> /dev/null
+
+./configure $*
+
+popd &> /dev/null

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "configure": "node-gyp configure",
     "build": "node-gyp build",
-    "test": "make test"
+    "test": "make test",
+    "preinstall": "node util/configure",
+    "install": "node-gyp rebuild"
   },
   "keywords": [
     "kafka",

--- a/util/configure.js
+++ b/util/configure.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var query = process.argv[2];
+
+var fs = require('fs');
+var path = require('path');
+
+var baseDir = path.resolve(__dirname, '../');
+
+var isWin = /^win/.test(process.platform);
+
+// Skip running this if we are running on a windows system
+if (isWin) {
+  process.exit(0);
+}
+
+var childProcess = require('child_process');
+
+try {
+  childProcess.execSync('./configure', {
+    cwd: baseDir,
+    stdio: [0,1,2]
+  });
+  process.exit(0);
+} catch (e) {
+  process.exit(1);
+}

--- a/util/get-env.js
+++ b/util/get-env.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var env = process.argv[2];
+var def = process.argv[3] || '';
+
+process.stdout.write(process.env[env] || def);

--- a/util/has-lib.js
+++ b/util/has-lib.js
@@ -1,0 +1,101 @@
+'use strict';
+
+/**
+ * Copied from node-canvas library
+ */
+// https://raw.githubusercontent.com/Automattic/node-canvas/master/util/has_lib.js
+
+var query = process.argv[2];
+var fs = require('fs');
+var childProcess = require('child_process');
+
+var SYSTEM_PATHS = [
+  '/lib',
+  '/usr/lib',
+  '/usr/local/lib',
+  '/opt/local/lib',
+  '/usr/lib/x86_64-linux-gnu',
+  '/usr/lib/i386-linux-gnu'
+];
+
+/**
+ * Checks for lib using ldconfig if present, or searching SYSTEM_PATHS
+ * otherwise.
+ * @param String library name, e.g. 'jpeg' in 'libjpeg64.so' (see first line)
+ * @return Boolean exists
+ */
+function hasSystemLib (lib) {
+  var libName = 'lib' + lib + '.+(so|dylib)';
+  var libNameRegex = new RegExp(libName);
+
+    // Try using ldconfig on linux systems
+  if (hasLdconfig()) {
+    try {
+      if (childProcess.execSync('ldconfig -p 2>/dev/null | grep -E "' + libName + '"').length) {
+        return true;
+      }
+    } catch (err) {
+      // noop -- proceed to other search methods
+    }
+  }
+
+    // Try checking common library locations
+  return SYSTEM_PATHS.some(function (systemPath) {
+    try {
+      var dirListing = fs.readdirSync(systemPath);
+      return dirListing.some(function (file) {
+        return libNameRegex.test(file);
+      });
+    } catch (err) {
+      return false;
+    }
+  });
+}
+
+/**
+ * Checks for ldconfig on the path and /sbin
+ * @return Boolean exists
+ */
+function hasLdconfig () {
+  try {
+    // Add /sbin to path as ldconfig is located there on some systems -- e.g.
+    // Debian (and it can still be used by unprivileged users):
+    childProcess.execSync('export PATH="$PATH:/sbin"');
+    process.env.PATH = '...';
+    // execSync throws on nonzero exit
+    childProcess.execSync('hash ldconfig 2>/dev/null');
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+/**
+ * Checks for lib using pkg-config.
+ * @param String library name
+ * @return Boolean exists
+ */
+function hasPkgconfigLib (lib) {
+  try {
+    // execSync throws on nonzero exit
+    childProcess.execSync('pkg-config --exists "' + lib + '" 2>/dev/null');
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+function main (query) {
+  switch (query) {
+    case 'sasl':
+    case 'lz4':
+      return hasSystemLib(query);
+    case 'openssl':
+    case 'ssl':
+      return hasPkgconfigLib(query);
+    default:
+      throw new Error('Unknown library: ' + query);
+  }
+}
+
+process.stdout.write(main(query).toString());

--- a/util/librdkafka-config-checker.js
+++ b/util/librdkafka-config-checker.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var query = process.argv[2];
+
+var fs = require('fs');
+var path = require('path');
+
+var baseDir = path.resolve(__dirname, '../');
+var librdkafkaConfig = path.resolve(baseDir, 'deps', 'librdkafka', 'config.h');
+
+var isWin = /^win/.test(process.platform);
+
+// Skip running this if we are running on a windows system
+if (isWin) {
+  process.stdout.write('0');
+  process.exit(0);
+}
+
+var buf;
+
+try {
+  buf = fs.readFileSync(librdkafkaConfig);
+} catch (e) {
+  if (e.code === 'ENOENT') {
+    process.stderr.write('Please run configure before using this script\n');
+    process.exit(1);
+  }
+}
+
+var bufLines = buf.toString().split('\n');
+
+// Get rid of comment lines and get rid of empty lines
+bufLines = bufLines.map(function(line) {
+  return line.trim();
+}).filter(function(line) {
+  if (line === '') {
+    return false;
+  }
+
+  if (line.startsWith('//')) {
+    return false;
+  }
+
+  if (line.startsWith('#pragma')) {
+    return false;
+  }
+
+  return true;
+});
+
+const defines = {};
+
+bufLines.forEach(function(line) {
+  if (line.startsWith('#define')) {
+    var modified = line.substring('#define'.length).trim();
+    var varSplit = modified.split(' ');
+    if (varSplit.length >= 2 && varSplit[0] && varSplit[1]) {
+      defines[varSplit[0]] = varSplit[1];
+    }
+  }
+});
+
+if (defines.hasOwnProperty(query)) {
+  process.stdout.write(defines[query]);
+} else {
+  process.stdout.write('0');
+}


### PR DESCRIPTION
Rather than relying on users to specify that they have SASL, we can use
librdkafka's built in checking to find out. If we parse out the header
file that is made we can export environment variables so node-gyp can
configure itself appropriately.

This commit should also improve development because configure is now run
at install time only. It means when developing you do not need to
recompile the entirety of librdkafka with each minor change