### PR TITLE
Document producer timestamp and opaque parameters in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ To see the configuration options available to you, see the [Configuration](#conf
 |`producer.disconnect()`| Disconnects from the broker. <br><br>The `disconnect()` method emits the `disconnected` event when it has disconnected or `error` if something went wrong. |
 |`producer.poll()` | Polls the producer for delivery reports or other events to be transmitted via the emitter. <br><br>In order to get the events in `librdkafka`'s queue to emit, you must call this regularly. |
 |`producer.setPollInterval(interval)` | Polls the producer on this interval, handling disconnections and reconnection. Set it to 0 to turn it off. |
-|`producer.produce(topic, partition, msg, key)`| Sends a message. <br><br>The `produce()` method throws when produce would return an error. Ordinarily, this is just if the queue is full. |
+|`producer.produce(topic, partition, msg, key, timestamp, opaque)`| Sends a message. <br><br>The `produce()` method throws when produce would return an error. Ordinarily, this is just if the queue is full. |
 |`producer.flush(timeout, callback)`| Flush the librdkafka internal queue, sending all messages. Default timeout is 500ms |
 
 ##### Events


### PR DESCRIPTION
Add in timestamp and opaque parameters to REAME docs for
producer.produce() to match code https://github.com/Blizzard/node-rdkafka/blob/48c026e7f086f7f3592ddcf89e75b8fb48290f99/lib/producer.js#L204