### PR TITLE
Updated gyp file for both librdkafka 0.9.5 and 0.11

### DIFF
--- a/deps/librdkafka.gyp
+++ b/deps/librdkafka.gyp
@@ -114,11 +114,17 @@
             },
           }
         ],
-        [ "<(WITH_SASL)==1",
+        [ 'OS!="win" and <(WITH_SASL)==1',
           {
             'sources': [
-              'librdkafka/src/rdkafka_sasl.c',
-              'librdkafka/src/rdkafka_sasl_cyrus.c'
+              '<!@(find librdkafka/src -name rdkafka_sasl*.c ! -name rdkafka_sasl_win32*.c )'
+            ]
+          }
+        ],
+        [ 'OS=="win" and <(WITH_SASL)==1',
+          {
+            'sources': [
+              '<!@(find librdkafka/src -name rdkafka_sasl*.c ! -name rdkafka_sasl_cyrus*.c )'
             ]
           }
         ]


### PR DESCRIPTION
Works with both librdkafka 0.9.5 and current master where new sasl files
need to be compiled.
Conditional for win32, but tested on macOS not Windows