### PR TITLE
Make consumer example more verbose on config error

### DIFF
--- a/examples/consumer.md
+++ b/examples/consumer.md
@@ -26,7 +26,8 @@ var stream = Kafka.KafkaConsumer.createReadStream({
   objectMode: false
 });
 
-stream.on('error', function() {
+stream.on('error', function(err) {
+  if (err) console.log(err);
   process.exit(1);
 });
 


### PR DESCRIPTION
... such as a missing or typo on `group.id`, which it just quit silently now