### PR TITLE
Fixed README Document Inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ This library includes two utility functions for detecting the status of your ins
 You can get the features supported by your compile of `librdkafka` by reading the variable "features" on the root of the `node-rdkafka` object.
 
 ```js
-const kafka = require('node-rdkafka');
-console.log(kafka.features);
+const Kafka = require('node-rdkafka');
+console.log(Kafka.features);
 
 // #=> [ 'gzip', 'snappy', 'ssl', 'sasl', 'regex', 'lz4' ]
 ```
@@ -104,8 +104,8 @@ console.log(kafka.features);
 You can also get the version of `librdkafka`
 
 ```js
-const kafka = require('node-rdkafka');
-console.log(kafka.librdkafkaVersion);
+const Kafka = require('node-rdkafka');
+console.log(Kafka.librdkafkaVersion);
 
 // #=> 0.9.5
 ```


### PR DESCRIPTION
In the README example code, the `node-rdkafka` import examples alias to `kafka` (with a lower-case  k). Subsequent examples use a different convention -- pulling in libraries from `Kafka` (e.g. `new Kafka.Producer(...)`).

It's a minor inconsistency, but could lead to frustration with novice Node developers.