### PR TITLE
Initial attempt at Windows support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -28,8 +28,8 @@
         [ 'OS=="win"', {
           "sources": [ '<!@(findwin src *.cc)' ],
           "include_dirs": [
-		      "deps/librdkafka/src-cpp",
-		  ],
+            "deps/librdkafka/src-cpp",
+          ],
           'configurations': {
             'Debug': {
               'msvs_settings': {
@@ -68,16 +68,16 @@
             # .deb packages.
             {
                 'conditions': [
-				  [ 'OS!="win"', {
+                  [ 'OS!="win"', {
                       "libraries": ["-lrdkafka", "-lrdkafka++"],
                       "include_dirs": [
                           "/usr/include/librdkafka",
                           "/usr/local/include/librdkafka"
                       ],
-				  }],
+                  }],
                   [ 'OS=="win"', {
                       "libraries": ["-l../deps/win32-runtime/librdkafka", "-l../deps/win32-runtime/librdkafkacpp"],
-			      }],
+                  }],
 				],
             },
         ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,19 +1,60 @@
 {
   "variables": {
       # may be redefined in command line on configuration stage
-      "BUILD_LIBRDKAFKA%": "<!(echo ${BUILD_LIBRDKAFKA:-1})",
-      "WITH_SASL%": "<!(echo ${WITH_SASL:-1})",
-      "WITH_LZ4%": "<!(echo ${WITH_LZ4:-0})"
+      'conditions': [
+        [ 'OS=="win"', {
+          "BUILD_LIBRDKAFKA%": "<!(IF DEFINED BUILD_LIBRDKAFKA (echo %BUILD_LIBRDKAFKA%) ELSE (echo 0))",
+          "WITH_SASL%": "<!(IF DEFINED WITH_SASL (echo %WITH_SASL%) ELSE (echo 0))",
+          "WITH_LZ4%": "<!(IF DEFINED WITH_LZ4 (echo %WITH_LZ4%) ELSE (echo 0))"
+        }],
+        [ 'OS!="win"', {
+          "BUILD_LIBRDKAFKA%": "<!(echo ${BUILD_LIBRDKAFKA:-1})",
+          "WITH_SASL%": "<!(echo ${WITH_SASL:-1})",
+          "WITH_LZ4%": "<!(echo ${WITH_LZ4:-0})"
+        }]
+      ]
   },
   "targets": [
     {
       "target_name": "node-librdkafka",
-      "sources": [ "<!@(ls -1 src/*.cc)", ],
       "include_dirs": [
         "<!(node -e \"require('nan')\")",
         "<(module_root_dir)/"
       ],
       'conditions': [
+        [ 'OS!="win"', {
+          "sources": [ "<!@(ls -1 src/*.cc)", ]
+        }],
+        [ 'OS=="win"', {
+          "sources": [ '<!@(findwin src *.cc)' ],
+          "include_dirs": [
+		      "deps/librdkafka/src-cpp",
+		  ],
+          'configurations': {
+            'Debug': {
+              'msvs_settings': {
+                'VCLinkerTool': {
+                  'SetChecksum': 'true'
+                },
+                'VCCLCompilerTool': {
+                  'RuntimeTypeInfo': 'true',
+                  'RuntimeLibrary': '1', # /MTd
+                }
+              },
+            },
+            'Release': {
+              'msvs_settings': {
+                'VCLinkerTool': {
+                  'SetChecksum': 'true'
+                },
+                'VCCLCompilerTool': {
+                  'RuntimeTypeInfo': 'true',
+                  'RuntimeLibrary': '0', # /MT
+                }
+              },
+            }
+          }
+        }],
         [ "<(BUILD_LIBRDKAFKA)==1",
             {
                 "dependencies": [
@@ -26,11 +67,18 @@
             # install the librdkafka1, librdkafka++1, and librdkafka-dev
             # .deb packages.
             {
-                "libraries": ["-lrdkafka", "-lrdkafka++"],
-                "include_dirs": [
-                    "/usr/include/librdkafka",
-                    "/usr/local/include/librdkafka"
-                ],
+                'conditions': [
+				  [ 'OS!="win"', {
+                      "libraries": ["-lrdkafka", "-lrdkafka++"],
+                      "include_dirs": [
+                          "/usr/include/librdkafka",
+                          "/usr/local/include/librdkafka"
+                      ],
+				  }],
+                  [ 'OS=="win"', {
+                      "libraries": ["-l../deps/win32-runtime/librdkafka", "-l../deps/win32-runtime/librdkafkacpp"],
+			      }],
+				],
             },
         ],
         [
@@ -41,14 +89,6 @@
             ],
             'cflags_cc!': [
               '-fno-rtti'
-            ]
-          }
-        ],
-        [
-          'OS=="win"',
-          {
-            'cflags_cc' : [
-              '-std=c++11'
             ]
           }
         ],

--- a/findwin.cmd
+++ b/findwin.cmd
@@ -1,0 +1,20 @@
+@echo off
+set sdir=%1
+set mask=%2
+set nmsk=%3
+setlocal disabledelayedexpansion
+for /f "delims=" %%A in ('forfiles /s /p %sdir% /m %mask% /c "cmd /c echo @path"') do (
+  set "file=%%~A"
+  setlocal enabledelayedexpansion
+  set "file=!file:%CD%\=!"
+  set "file=!file:\=/!"
+  if [%nmsk%] == [] (
+    echo !file!
+  ) else (
+    echo.!file!|findstr /C:"%nmsk%" >nul 2>&1
+    if errorlevel 1 (
+      echo !file!
+    )
+  )
+  endlocal
+)

--- a/nuget-dep.js
+++ b/nuget-dep.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const download = require('download');
+const decompress = require('decompress');
+const path = require('path');
+const os = require('os');
+const process = require('process');
+
+const filename = 'librdkafka.redist.zip';
+const downloadDestFolder = path.join('.', 'deps');
+const extractDestFolder = path.join('.', 'deps', 'win32-runtime');
+const extensions = [ '.lib', '.dll' ];
+
+if(os.type() == 'Windows_NT') {
+	
+	var architecture = process.arch.includes('64') ? 'x64' : 'x86';
+	
+	download('https://www.nuget.org/api/v2/package/librdkafka.redist/', downloadDestFolder, { filename: filename })
+	.then(() => {
+		console.log('librdkafka.redist downloaded.');
+		decompress(path.join('.', downloadDestFolder, filename), '.', {
+			filter: file => file.path.includes(architecture) && extensions.includes(path.extname(file.path)),
+			map: file => {
+				file.path = path.join(extractDestFolder, path.basename(file.path));
+				return file;
+			}
+		})
+		.then(files => console.log('librdkafka.redist extracted.'));
+	})
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "configure": "node-gyp configure",
     "build": "node-gyp build",
+    "preinstall": "node ./nuget-dep.js",
+    "install": "node-gyp rebuild",
     "test": "make test"
   },
   "keywords": [
@@ -32,7 +34,9 @@
     "jsdoc": "^3.4.0",
     "toolkit-jsdoc": "^1.0.0",
     "mocha": "2.x",
-    "node-gyp": "3.x"
+    "node-gyp": "3.x",
+    "download": "^6.2.5",
+    "decompress": "^4.2.0"
   },
   "dependencies": {
     "bindings": "1.x",

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "jsdoc": "^3.4.0",
     "toolkit-jsdoc": "^1.0.0",
     "mocha": "2.x",
-    "node-gyp": "3.x",
-    "download": "^6.2.5",
-    "decompress": "^4.2.0"
+    "node-gyp": "3.x"
   },
   "dependencies": {
     "bindings": "1.x",
-    "nan": "2.x"
+    "nan": "2.x",
+    "download": "^6.2.5",
+    "decompress": "^4.2.0"
   },
   "engines": {
     "npm": "^2.7.3"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "configure": "node-gyp configure",
     "build": "node-gyp build",
-    "preinstall": "node ./nuget-dep.js",
-    "install": "node-gyp rebuild",
+    "install": "node ./nuget-dep.js && node-gyp rebuild",
     "test": "make test"
   },
   "keywords": [

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -378,7 +378,11 @@ void KafkaConsumerConsumeLoop::Execute(const ExecutionMessageBus& bus) {
       // when in consume loop mode
       // Randomise the wait time to avoid contention on different
       // slow topics
+	  #if defined(_WIN32)
       std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(rand() * 1000 / RAND_MAX)));
+      #else
+      std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(rand_r(&m_rand_seed) * 1000 / RAND_MAX)));
+      #endif
     } else if (
       b.err() == RdKafka::ERR__TIMED_OUT ||
       b.err() == RdKafka::ERR__TIMED_OUT_QUEUE) {

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -378,14 +378,14 @@ void KafkaConsumerConsumeLoop::Execute(const ExecutionMessageBus& bus) {
       // when in consume loop mode
       // Randomise the wait time to avoid contention on different
       // slow topics
-      usleep(static_cast<int>(rand_r(&m_rand_seed) * 1000 * 1000 / RAND_MAX));
+      std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(rand() * 1000 / RAND_MAX)));
     } else if (
       b.err() == RdKafka::ERR__TIMED_OUT ||
       b.err() == RdKafka::ERR__TIMED_OUT_QUEUE) {
       // If it is timed out this could just mean there were no
       // new messages fetched quickly enough. This isn't really
       // an error that should kill us.
-      usleep(500*1000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
     } else if (b.err() == RdKafka::ERR_NO_ERROR) {
       bus.Send(b.data<RdKafka::Message*>());
     } else {

--- a/src/workers.h
+++ b/src/workers.h
@@ -12,7 +12,8 @@
 
 #include <uv.h>
 #include <nan.h>
-#include <unistd.h>
+#include <chrono>
+#include <thread>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Uses [NuGet librdkafka - redistributable](https://www.nuget.org/packages/librdkafka.redist/) rather than compiling librdkafka for Windows.  Should address #45.

Also replaced `usleep` function with cross-platform `std::this_thread::sleep_for` alternative.

