### PR TITLE
Use strict equal assertions in test

### DIFF
--- a/e2e/producer.spec.js
+++ b/e2e/producer.spec.js
@@ -50,7 +50,7 @@ describe('Producer', function() {
 
         // Ensure it is in the correct format
         t.ok(metadata.orig_broker_name, 'Broker name is not set');
-        t.ok(metadata.orig_broker_id !== undefined, 'Broker id is not set');
+        t.notStrictEqual(metadata.orig_broker_id, undefined, 'Broker id is not set');
         t.equal(Array.isArray(metadata.brokers), true);
         t.equal(Array.isArray(metadata.topics), true);
 
@@ -68,7 +68,7 @@ describe('Producer', function() {
       producer.once('delivery-report', function(err, report) {
         clearInterval(tt);
         t.ifError(err);
-        t.ok(report !== undefined);
+        t.notStrictEqual(report, undefined);
         t.strictEqual(typeof report.topic, 'string');
         t.strictEqual(typeof report.partition, 'number');
         t.strictEqual(typeof report.offset, 'number');
@@ -89,7 +89,7 @@ describe('Producer', function() {
       producer.once('delivery-report', function(err, report) {
         clearInterval(tt);
         t.ifError(err);
-        t.ok(report !== undefined);
+        t.notStrictEqual(report, undefined);
         t.strictEqual(report.value, undefined);
         t.strictEqual(typeof report.topic, 'string');
         t.strictEqual(typeof report.partition, 'number');
@@ -111,7 +111,7 @@ describe('Producer', function() {
       producer.once('delivery-report', function(err, report) {
         clearInterval(tt);
         t.ifError(err);
-        t.ok(report !== undefined);
+        t.notStrictEqual(report, undefined);
         t.strictEqual(report.value, undefined);
         t.strictEqual(typeof report.topic, 'string');
         t.strictEqual(typeof report.partition, 'number');
@@ -133,7 +133,7 @@ describe('Producer', function() {
       producer.once('delivery-report', function(err, report) {
         clearInterval(tt);
         t.ifError(err);
-        t.ok(report !== undefined);
+        t.notStrictEqual(report, undefined);
         t.strictEqual(typeof report.topic, 'string');
         t.strictEqual(typeof report.partition, 'number');
         t.strictEqual(typeof report.offset, 'number');
@@ -159,7 +159,7 @@ describe('Producer', function() {
       producer
         .on('delivery-report', function(err, report) {
           t.ifError(err);
-          t.ok(report !== undefined);
+          t.notStrictEqual(report, undefined);
           t.strictEqual(typeof report.topic, 'string');
           t.strictEqual(typeof report.partition, 'number');
           t.strictEqual(typeof report.offset, 'number');
@@ -211,7 +211,7 @@ describe('Producer', function() {
       producer.once('delivery-report', function(err, report) {
         clearInterval(tt);
         t.ifError(err);
-        t.ok(report !== undefined);
+        t.notStrictEqual(report, undefined);
         t.strictEqual(typeof report.topic, 'string');
         t.strictEqual(typeof report.partition, 'number');
         t.strictEqual(typeof report.offset, 'number');
@@ -233,7 +233,7 @@ describe('Producer', function() {
       producer.once('delivery-report', function(err, report) {
         clearInterval(tt);
         t.ifError(err);
-        t.ok(report !== undefined);
+        t.notStrictEqual(report, undefined);
 
         t.strictEqual(typeof report.topic, 'string');
         t.strictEqual(typeof report.partition, 'number');
@@ -253,7 +253,7 @@ describe('Producer', function() {
 
       producer.once('delivery-report', function(err, report) {
         t.ifError(err);
-        t.ok(report !== undefined);
+        t.notStrictEqual(report, undefined);
 
         t.strictEqual(typeof report.topic, 'string');
         t.strictEqual(typeof report.partition, 'number');
@@ -284,7 +284,7 @@ describe('Producer', function() {
 
       producer.once('delivery-report', function(err, report) {
         t.ifError(err);
-        t.ok(report !== undefined);
+        t.notStrictEqual(report, undefined);
 
         t.deepEqual(buf, report.key);
         done();

--- a/e2e/producer.spec.js
+++ b/e2e/producer.spec.js
@@ -69,10 +69,10 @@ describe('Producer', function() {
         clearInterval(tt);
         t.ifError(err);
         t.ok(report !== undefined);
-        t.ok(typeof report.topic === 'string');
-        t.ok(typeof report.partition === 'number');
-        t.ok(typeof report.offset === 'number');
-        t.ok( report.key === null);
+        t.strictEqual(typeof report.topic, 'string');
+        t.strictEqual(typeof report.partition, 'number');
+        t.strictEqual(typeof report.offset, 'number');
+        t.strictEqual( report.key, null);
         done();
       });
 
@@ -90,10 +90,10 @@ describe('Producer', function() {
         clearInterval(tt);
         t.ifError(err);
         t.ok(report !== undefined);
-        t.ok(report.value === undefined);
-        t.ok(typeof report.topic === 'string');
-        t.ok(typeof report.partition === 'number');
-        t.ok(typeof report.offset === 'number');
+        t.strictEqual(report.value, undefined);
+        t.strictEqual(typeof report.topic, 'string');
+        t.strictEqual(typeof report.partition, 'number');
+        t.strictEqual(typeof report.offset, 'number');
         t.equal(report.key, 'key');
         done();
       });
@@ -112,10 +112,10 @@ describe('Producer', function() {
         clearInterval(tt);
         t.ifError(err);
         t.ok(report !== undefined);
-        t.ok(report.value === undefined);
-        t.ok(typeof report.topic === 'string');
-        t.ok(typeof report.partition === 'number');
-        t.ok(typeof report.offset === 'number');
+        t.strictEqual(report.value, undefined);
+        t.strictEqual(typeof report.topic, 'string');
+        t.strictEqual(typeof report.partition, 'number');
+        t.strictEqual(typeof report.offset, 'number');
         t.equal(report.key.length > 3, true);
         done();
       });
@@ -134,9 +134,9 @@ describe('Producer', function() {
         clearInterval(tt);
         t.ifError(err);
         t.ok(report !== undefined);
-        t.ok(typeof report.topic === 'string');
-        t.ok(typeof report.partition === 'number');
-        t.ok(typeof report.offset === 'number');
+        t.strictEqual(typeof report.topic, 'string');
+        t.strictEqual(typeof report.partition, 'number');
+        t.strictEqual(typeof report.offset, 'number');
         t.equal(report.opaque, 'opaque');
         done();
       });
@@ -160,9 +160,9 @@ describe('Producer', function() {
         .on('delivery-report', function(err, report) {
           t.ifError(err);
           t.ok(report !== undefined);
-          t.ok(typeof report.topic === 'string');
-          t.ok(typeof report.partition === 'number');
-          t.ok(typeof report.offset === 'number');
+          t.strictEqual(typeof report.topic, 'string');
+          t.strictEqual(typeof report.partition, 'number');
+          t.strictEqual(typeof report.offset, 'number');
           verified_received++;
           if (verified_received === max) {
             clearInterval(tt);
@@ -212,9 +212,9 @@ describe('Producer', function() {
         clearInterval(tt);
         t.ifError(err);
         t.ok(report !== undefined);
-        t.ok(typeof report.topic === 'string');
-        t.ok(typeof report.partition === 'number');
-        t.ok(typeof report.offset === 'number');
+        t.strictEqual(typeof report.topic, 'string');
+        t.strictEqual(typeof report.partition, 'number');
+        t.strictEqual(typeof report.offset, 'number');
         t.ok(report.key.toString(), 'key');
         t.equal(report.value.toString(), 'hai');
         done();
@@ -235,11 +235,11 @@ describe('Producer', function() {
         t.ifError(err);
         t.ok(report !== undefined);
 
-        t.ok(typeof report.topic === 'string');
-        t.ok(typeof report.partition === 'number');
-        t.ok(typeof report.offset === 'number');
+        t.strictEqual(typeof report.topic, 'string');
+        t.strictEqual(typeof report.partition, 'number');
+        t.strictEqual(typeof report.offset, 'number');
         t.equal(report.key.toString(), '', 'key should be an empty string');
-        t.ok(report.value.toString() === '', 'payload should be an empty string');
+        t.strictEqual(report.value.toString(), '', 'payload should be an empty string');
         done();
       });
 
@@ -255,11 +255,11 @@ describe('Producer', function() {
         t.ifError(err);
         t.ok(report !== undefined);
 
-        t.ok(typeof report.topic === 'string');
-        t.ok(typeof report.partition === 'number');
-        t.ok(typeof report.offset === 'number');
-        t.ok(report.key === null, 'key should be null');
-        t.ok(report.value === null, 'payload should be null');
+        t.strictEqual(typeof report.topic, 'string');
+        t.strictEqual(typeof report.partition, 'number');
+        t.strictEqual(typeof report.offset, 'number');
+        t.strictEqual(report.key, null, 'key should be null');
+        t.strictEqual(report.value, null, 'payload should be null');
         done();
       });
 


### PR DESCRIPTION
These methods yield better error messages if the test fails.