### PR TITLE
Fix Client.connectedTime method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -240,7 +240,7 @@ Client.prototype.connectedTime = function() {
   if (!this.isConnected()) {
     return 0;
   }
-  return Date.now() - this.metrics.connectionOpened();
+  return Date.now() - this.metrics.connectionOpened;
 };
 
 /**


### PR DESCRIPTION
Small bug found while using the repo :) Please see below block for error message

```
/Users/philipyoo/Scality/wip/blizzard-kafka/node_modules/node-rdkafka/lib/client.js:243
  return Date.now() - this.metrics.connectionOpened();
                                   ^
TypeError: this.metrics.connectionOpened is not a function
```
