### PR TITLE
npm install now self contained

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "node-gyp build",
     "test": "make test",
     "preinstall": "node util/configure",
-    "install": "node-gyp rebuild"
+    "install": "./configure; node-gyp rebuild"
   },
   "keywords": [
     "kafka",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "node-gyp build",
     "test": "make test",
     "preinstall": "node util/configure",
-    "install": "./configure; node-gyp rebuild"
+    "install": "./configure; npm i nan; node-gyp rebuild"
   },
   "keywords": [
     "kafka",


### PR DESCRIPTION
I wanted npm install to "just work" without me having to dance around it with scripts so I embedded the missing things in the package.json install script itself.

With this change the package works out of the box on node 8.x (8.0.0 and 8.8.1 were tested via the official docker image for NodeJS - note the alpine flavours don't work due to other issues with the compiler toolchain so you need the "proper" nodejs image not the alpine based)

I'm not sure if you wanted this fix in the first place or not, but figured I should give back so here it is.

Thanks for publishing the code, and much love to your work in general. I'm a longtime fan of Blizzard games.
