### PR TITLE
Add the message timestamp to the consumer payload

### DIFF
--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -111,6 +111,7 @@ function KafkaConsumer(conf, topicConf) {
    * @property {number} offset - the offset of the message
    * @property {string} key - the message key
    * @property {number} size - message size, in bytes.
+   * @property {number} timestamp - message timestamp
    */
 
   Client.call(this, conf, Kafka.KafkaConsumer, topicConf);

--- a/src/common.cc
+++ b/src/common.cc
@@ -454,6 +454,8 @@ v8::Local<v8::Object> ToV8Object(RdKafka::Message *message, bool include_payload
       Nan::New<v8::Number>(message->offset()));
     Nan::Set(pack, Nan::New<v8::String>("partition").ToLocalChecked(),
       Nan::New<v8::Number>(message->partition()));
+    Nan::Set(pack, Nan::New<v8::String>("timestamp").ToLocalChecked(),
+      Nan::New<v8::Number>(message->timestamp().timestamp));
 
     return pack;
   } else {


### PR DESCRIPTION
As with Kafka brokers >=0.10.0 support timestamping of events it would be nice to have that field available.