### PR TITLE
Fix draining of ProducerStream in object mode

### DIFF
--- a/lib/producer-stream.js
+++ b/lib/producer-stream.js
@@ -201,6 +201,7 @@ function writev(producer, topic, chunks, cb) {
   // @todo maybe a produce batch method?
   var doneCount = 0;
   var err = null;
+  var chunk = null;
 
   function maybeDone(e) {
     if (e) {
@@ -213,7 +214,12 @@ function writev(producer, topic, chunks, cb) {
   }
 
   for (var i = 0; i < chunks.length; i++) {
-    producer.produce(topic, null, chunks[i], null);
+    chunk = chunks[i];
+    if (Buffer.isBuffer(chunk)) {
+      producer.produce(topic, null, chunk, null);
+    } else {
+      producer.produce(chunk.topic, chunk.partition, chunk.value, chunk.key, chunk.timestamp, chunk.opaque);
+    }
     maybeDone();
   }
 


### PR DESCRIPTION
Experienced by myself and as reported by #294, a `ProducerStream` in `objectMode` being drained throws an error: `'topic' == undefined`.

I managed to add a test case that reproduces this issue. After adding another for a streams not in `objectMode` to make sure we don't regress, I implemented a simple fix, getting both tests to pass.

I'm new to the codebase and open to any suggestions for a different approach 😄 .