### PR TITLE
emit disconnected event on connect failure

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -174,6 +174,8 @@ Client.prototype.connect = function(metadataOptions, cb) {
 
         next(err); return;
       }, 10000).unref();
+      
+      self.emit('disconnected', self.metrics);
     } else {
 
       next(err);

--- a/lib/client.js
+++ b/lib/client.js
@@ -175,7 +175,7 @@ Client.prototype.connect = function(metadataOptions, cb) {
         next(err); return;
       }, 10000).unref();
       
-      self.emit('disconnected', self.metrics);
+      self.emit('connection.failure', self.metrics);
     } else {
 
       next(err);


### PR DESCRIPTION
if getMetadata call fails, client disconnects itself silently. add a disconnect event so I can call connect again to reconnect.