### PR TITLE
add auto reconnect example

### DIFF
--- a/examples/producer.md
+++ b/examples/producer.md
@@ -65,6 +65,16 @@ producer.on('disconnected', function(arg) {
   console.log('producer disconnected. ' + JSON.stringify(arg));
 });
 
+function connect(){
+  producer.connect(undefined, function(err) {
+    if(err) {
+      console.error(err)
+      // auto retry connection if connect fails
+      connect();
+    }
+  })
+}
+
 //starting the producer
-producer.connect();
+connect();
 ```


### PR DESCRIPTION
The client doesn't reconnect if connection to kafka fails in initial connection. I don't know if it is designed but I was expecting the client to retry.

adding an example code here