### PR TITLE
Normalize API

### DIFF
--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -89,12 +89,12 @@ function KafkaConsumer(conf, topicConf) {
   if (onOffsetCommit && typeof onOffsetCommit === 'boolean') {
     conf.offset_commit_cb = function(err, offsets) {
       // Emit the event
-      self.emit('offset.commit', offsets);
+      self.emit('offset.commit', err, offsets);
     };
   } else if (onOffsetCommit && typeof onOffsetCommit === 'function') {
     conf.offset_commit_cb = function(err, offsets) {
       // Emit the event
-      self.emit('offset.commit', offsets);
+      self.emit('offset.commit', err, offsets);
       onOffsetCommit.call(self, err, offsets);
     };
   }


### PR DESCRIPTION
I want to restart my process in the event of a commit fail error.
In order to have access to the `err` object, I have to use the `offset_commit_cb` API.
I can't rely on the event emitted.

I'm not 100% it's the best approach to the problem. At least, **it's a breaking change**.

Also, I'm wondering if we shouldn't list `offset.commit` in the events table
> The following table lists important methods for this API.