### PR TITLE
Add typescript interface for consumer stream api messages

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -163,6 +163,16 @@ declare interface ConsumerStream extends NodeJS.ReadStream {
     consumer: KafkaConsumer
 }
 
+declare interface ConsumerStreamMessage {
+  value: Buffer,
+  size: number,
+  topic: string,
+  offset: number,
+  partition: number,
+  key?: string,
+  timestamp?: number
+}
+
 export function createReadStream(conf: any, topicConf: any, streamOptions: any): ConsumerStream;
 
 export function createWriteStream(conf: any, topicConf: any, streamOptions: any): ProducerStream;


### PR DESCRIPTION
Added a new interface to the definition file to allow typings on
messages received via the consumer stream API for example.

```typescript
stream.on('data', (message: Kafka.ConsumerStreamMessage) => {
  console.log('Got message');
  console.log(message.value.toString());
});
```