### PR TITLE
Add missing producer method

### DIFF
--- a/src/producer.cc
+++ b/src/producer.cc
@@ -66,6 +66,7 @@ void Producer::Init(v8::Local<v8::Object> exports) {
   Nan::SetPrototypeMethod(tpl, "connect", NodeConnect);
   Nan::SetPrototypeMethod(tpl, "disconnect", NodeDisconnect);
   Nan::SetPrototypeMethod(tpl, "getMetadata", NodeGetMetadata);
+  Nan::SetPrototypeMethod(tpl, "queryWatermarkOffsets", NodeQueryWatermarkOffsets);  // NOLINT
   Nan::SetPrototypeMethod(tpl, "poll", NodePoll);
 
   /*


### PR DESCRIPTION
@webmakersteve I was trying to use `queryWatermarkOffsets` on `producer` and it was erroring out.