### PR TITLE
Accept `connectOptions` with ProducerStream constructor

### DIFF
--- a/lib/producer-stream.js
+++ b/lib/producer-stream.js
@@ -87,8 +87,8 @@ function ProducerStream(producer, options) {
 
 }
 
-ProducerStream.prototype.connect = function() {
-  this.producer.connect({}, function(err, data) {
+ProducerStream.prototype.connect = function(options) {
+  this.producer.connect(options, function(err, data) {
     if (err) {
       this.emit('error', err);
       return;

--- a/lib/producer-stream.js
+++ b/lib/producer-stream.js
@@ -65,6 +65,7 @@ function ProducerStream(producer, options) {
   this.topicName = options.topic;
 
   this.autoClose = options.autoClose === undefined ? true : !!options.autoClose;
+  this.connectOptions = options.connectOptions || {};
 
   this.producer.setPollInterval(options.pollInterval || 1000);
 
@@ -74,7 +75,7 @@ function ProducerStream(producer, options) {
 
   // Connect to the producer. Unless we are already connected
   if (!this.producer.isConnected()) {
-    this.connect();
+    this.connect(this.connectOptions);
   }
 
   var self = this;

--- a/test/producer-stream.spec.js
+++ b/test/producer-stream.spec.js
@@ -87,6 +87,25 @@ module.exports = {
         });
       },
 
+      'forwards connectOptions to client options when provided': function(cb) {
+        var testClientOptions = { timeout: 3000 };
+
+        fakeClient._isConnected = false;
+        fakeClient.isConnected = function() {
+          return false;
+        };
+        var fakeConnect = fakeClient.connect
+        fakeClient.connect = function(opts, callback) {
+          t.deepEqual(opts, testClientOptions);
+          cb();
+        };
+
+        var stream = new ProducerStream(fakeClient, {
+          topic: 'topic',
+          connectOptions: testClientOptions
+        });
+      },
+
       'automatically disconnects when autoclose is not provided': function(cb) {
         fakeClient.once('disconnected', cb);
 

--- a/test/producer-stream.spec.js
+++ b/test/producer-stream.spec.js
@@ -94,7 +94,7 @@ module.exports = {
         fakeClient.isConnected = function() {
           return false;
         };
-        var fakeConnect = fakeClient.connect
+        var fakeConnect = fakeClient.connect;
         fakeClient.connect = function(opts, callback) {
           t.deepEqual(opts, testClientOptions);
           cb();


### PR DESCRIPTION
Mirroring the behaviour of the `ConsumerStream`, this adds the ability to forward connection options when creating a ProducerStream. Very useful when trying to control the client's `timeout` option, amongst other things.

I added a simple test verifying the option is being passed down from the constructor. I'm happy to make any other changes if required.