### PR TITLE
Grammar fix: plural messages

### DIFF
--- a/src/workers.cc
+++ b/src/workers.cc
@@ -501,7 +501,7 @@ void KafkaConsumerConsumeLoop::HandleErrorCallback() {
 /**
  * @brief KafkaConsumer get messages worker.
  *
- * This callback will get a number of message. Can be of use in streams or
+ * This callback will get a number of messages. Can be of use in streams or
  * places where you don't want an infinite loop managed in C++land and would
  * rather manage it in Node.
  *


### PR DESCRIPTION
-  Clarify that the function retrieves several messages,
   as opposed to getting "the number" of a message.

Signed-off-by: Sven-Thorsten Dietrich <thebigcorporation@gmail.com>