### PR TITLE
Prevent KafkaConsumerStream from losing it's KafkaConsumer reference

### DIFF
--- a/lib/kafka-consumer-stream.js
+++ b/lib/kafka-consumer-stream.js
@@ -358,7 +358,6 @@ KafkaConsumerStream.prototype.close = function(cb) {
   if (self.consumer._isConnected) {
     self.consumer.unsubscribe();
     self.consumer.disconnect(function() {
-      self.consumer = null;
       close();
     });
   }


### PR DESCRIPTION
As with #344, I ran into an issue with the `KafkaConsumer` reference being lost from the `KafkaConsumerStream` after closing the stream while it's reading at a high rate. 

Through the asynchronous nature of a `Stream`, it's possible there's some left to read even if the underlying consumer has been disconnected. A call in the `_read` methods to check whether the consumer is connected throws an error, as the consumer was set to null.

I don't believe that removing the reference does anything in the first place? Happy to be made of aware of anything, so I can help mitigate it some other way.