### PR TITLE
Link against built librdkafka.so, not the system librdkafka

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -64,6 +64,7 @@
                       'OS=="linux"',
                       {
                         "libraries": [
+                          "<(module_root_dir)/build/deps/librdkafka.so",
                           "<(module_root_dir)/build/deps/librdkafka++.so",
                           "-Wl,-rpath=<(module_root_dir)/build/deps",
                         ],


### PR DESCRIPTION
Build system links against system `librdkafka.so` even though it builds its own `librdkafka.so`.

This causes segfault when system librdkafka is built against different version of OpenSSL (often 1.1) than node's OpenSSL (1.0).

This fixes #372 for me.