### PR TITLE
Fix the build on windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -31,12 +31,24 @@
               '-std=c++11'
             ],
             'msvs_settings': {
+              'VCLinkerTool': {
+                'AdditionalDependencies': [
+                  'librdkafka.lib',
+                  'librdkafkacpp.lib'
+                ],
+                'AdditionalLibraryDirectories': [
+                  '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/'
+                ]
+              },
               'VCCLCompilerTool': {
                 'AdditionalOptions': [
                   '/GR'
                 ],
                 'AdditionalUsingDirectories': [
                   '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/'
+                ],
+                'AdditionalIncludeDirectories': [
+                  'deps/librdkafka/src-cpp'
                 ]
               }
             },


### PR DESCRIPTION
Add librdkafkacpp.lib to additional dependencies and update how the linker looks for libraries on windows. Solves [#389](https://github.com/Blizzard/node-rdkafka/issues/389).