### PR TITLE
Handle queuing errors when draining the ProducerStream

### DIFF
--- a/lib/producer-stream.js
+++ b/lib/producer-stream.js
@@ -239,7 +239,7 @@ function writev(producer, topic, chunks, cb) {
       if (ErrorCode.ERR__QUEUE_FULL === e.code) {
         retry(chunks.slice(i));
       } else {
-        maybeDone(e);
+        cb(e);
       }
       break;
     }

--- a/lib/producer-stream.js
+++ b/lib/producer-stream.js
@@ -214,14 +214,35 @@ function writev(producer, topic, chunks, cb) {
     }
   }
 
+  function retry(restChunks) {
+    // Poll for good measure
+    producer.poll();
+
+    // Just delay this thing a bit and pass the params
+    // backpressure will get exerted this way.
+    setTimeout(function() {
+      writev(producer, topic, restChunks, cb);
+    }, 500);
+  }
+
   for (var i = 0; i < chunks.length; i++) {
     chunk = chunks[i];
-    if (Buffer.isBuffer(chunk)) {
-      producer.produce(topic, null, chunk, null);
-    } else {
-      producer.produce(chunk.topic, chunk.partition, chunk.value, chunk.key, chunk.timestamp, chunk.opaque);
+
+    try {
+      if (Buffer.isBuffer(chunk)) {
+        producer.produce(topic, null, chunk, null);
+      } else {
+        producer.produce(chunk.topic, chunk.partition, chunk.value, chunk.key, chunk.timestamp, chunk.opaque);
+      }
+      maybeDone();
+    } catch (e) {
+      if (ErrorCode.ERR__QUEUE_FULL === e.code) {
+        retry(chunks.slice(i));
+      } else {
+        maybeDone(e);
+      }
+      break;
     }
-    maybeDone();
   }
 
 }


### PR DESCRIPTION
While the `librdkafka's` queue is full, trying to produce a message throws `Error: Local: Queue full`. This means the stream should backoff for a while, do a poll (things like delivery reports count towards the queue, fetching them might clear it up), and try again shortly after. Basically implementing backpressure, allowing Node streams to buffer messages.

This **is** implemented for writing a single message at the time, however, was missing for writing multiple chunks at once (when the stream is drained). I wrote tests to confirm this bug and then implemented a fix.

I'm happy to make any tweaks or additions if that's necessary, just let me know!