### PR TITLE
Back off ConsumerStream's consumption exponentially upon receiving time outs

### DIFF
--- a/lib/kafka-consumer-stream.js
+++ b/lib/kafka-consumer-stream.js
@@ -13,6 +13,8 @@ module.exports = KafkaConsumerStream;
 
 var Readable = require('stream').Readable;
 var util = require('util');
+var ErrorCode = require('./error').codes;
+var Retry = require('retry');
 
 util.inherits(KafkaConsumerStream, Readable);
 
@@ -129,40 +131,59 @@ function KafkaConsumerStream(consumer, options) {
  * @private
  */
 KafkaConsumerStream.prototype._read_message = function(size) {
-  if (this.messages.length > 0) {
-    return this.push(this.messages.shift());
-  }
-
-  if (!this.consumer) {
-    // This consumer is set to `null` in the close function
-    return;
-  }
-
-  if (!this.consumer.isConnected()) {
-    this.consumer.once('ready', function() {
-      // This is the way Node.js does it
-      // https://github.com/nodejs/node/blob/master/lib/fs.js#L1733
-      this._read(size);
-    }.bind(this));
-    return;
-  }
-
-  if (this.destroyed) {
-    return;
-  }
+  var consuming = Retry.operation({
+    minTimeout: 3 * 1000,
+    maxTimeout: 30 * 1000, 
+    factor: 2, // 3, 12, 27, 48
+    forever: true,
+    unref: true
+  });
 
   var self = this;
 
-  // If the size (number of messages) we are being advised to fetch is
-  // greater than or equal to the fetch size, use the fetch size.
-  // Only opt to use the size in case it is LESS than the fetch size.
-  // Essentially, we want to use the smaller value here
-  var fetchSize = size >= this.fetchSize ? this.fetchSize : size;
+  consuming.attempt(function(currentAttempt) {
+    if (self.messages.length > 0) {
+      return self.push(self.messages.shift());
+    }
 
-  this.consumer.consume(fetchSize, onread);
+    if (!self.consumer) {
+      // This consumer is set to `null` in the close function
+      return;
+    }
+
+    if (!self.consumer.isConnected()) {
+      self.consumer.once('ready', function() {
+        // This is the way Node.js does it
+        // https://github.com/nodejs/node/blob/master/lib/fs.js#L1733
+        self._read(size);
+      }.bind(self));
+      return;
+    }
+
+    if (self.destroyed) {
+      return;
+    }
+
+
+    // If the size (number of messages) we are being advised to fetch is
+    // greater than or equal to the fetch size, use the fetch size.
+    // Only opt to use the size in case it is LESS than the fetch size.
+    // Essentially, we want to use the smaller value here
+    var fetchSize = size >= self.fetchSize ? self.fetchSize : size;
+
+    self.consumer.consume(fetchSize, onread);
+  });
 
   function onread(err, messages) {
     if (err) {
+      if (
+        (err.code === ErrorCode.ERR__TIMED_OUT || 
+        err.code === ErrorCode.ERR__TIMED_OUT_QUEUE) &&
+        consuming.retry(err)
+      ) {
+        return;
+      }  
+
       // bad error
       if (self.autoClose) {
         self.destroy();
@@ -210,40 +231,58 @@ KafkaConsumerStream.prototype._read_message = function(size) {
  * @private
  */
 KafkaConsumerStream.prototype._read_buffer = function(size) {
-  if (this.messages.length > 0) {
-    return this.push(this.messages.shift());
-  }
-
-  if (!this.consumer) {
-    // This consumer is set to `null` in the close function
-    return;
-  }
-
-  if (!this.consumer.isConnected()) {
-    this.consumer.once('ready', function() {
-      // This is the way Node.js does it
-      // https://github.com/nodejs/node/blob/master/lib/fs.js#L1733
-      this._read(size);
-    }.bind(this));
-    return;
-  }
-
-  if (this.destroyed) {
-    return;
-  }
+  var consuming = Retry.operation({
+    minTimeout: 3 * 1000,
+    maxTimeout: 30 * 1000, 
+    factor: 2, // 3, 12, 27, 48
+    forever: true,
+    unref: true
+  });
 
   var self = this;
 
-  // If the size (number of messages) we are being advised to fetch is
-  // greater than or equal to the fetch size, use the fetch size.
-  // Only opt to use the size in case it is LESS than the fetch size.
-  // Essentially, we want to use the smaller value here
-  var fetchSize = size >= this.fetchSize ? this.fetchSize : size;
+  consuming.attempt(function (currentAttempt) {
+    if (self.messages.length > 0) {
+      return self.push(self.messages.shift());
+    }
 
-  this.consumer.consume(fetchSize, onread);
+    if (!self.consumer) {
+      // self consumer is set to `null` in the close function
+      return;
+    }
+
+    if (!self.consumer.isConnected()) {
+      self.consumer.once('ready', function() {
+        // self is the way Node.js does it
+        // https://github.com/nodejs/node/blob/master/lib/fs.js#L1733
+        self._read(size);
+      }.bind(self));
+      return;
+    }
+
+    if (self.destroyed) {
+      return;
+    }
+
+    // If the size (number of messages) we are being advised to fetch is
+    // greater than or equal to the fetch size, use the fetch size.
+    // Only opt to use the size in case it is LESS than the fetch size.
+    // Essentially, we want to use the smaller value here
+    var fetchSize = size >= self.fetchSize ? self.fetchSize : size;
+
+    self.consumer.consume(fetchSize, onread);
+  });
 
   function onread(err, messages) {
     if (err) {
+      if (
+        (err.code === ErrorCode.ERR__TIMED_OUT || 
+        err.code === ErrorCode.ERR__TIMED_OUT_QUEUE) &&
+        consuming.retry(err)
+      ) {
+        return;
+      }
+
       // bad error
       if (self.autoClose) {
         self.destroy();

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "dependencies": {
     "bindings": "1.x",
-    "nan": "2.x"
+    "nan": "2.x",
+    "retry": "^0.12.0"
   },
   "engines": {
     "npm": "^2.7.3"

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -533,6 +533,7 @@ void KafkaConsumerConsumeNum::Execute() {
       case RdKafka::ERR__TIMED_OUT:
       case RdKafka::ERR__TIMED_OUT_QUEUE:
         // Break of the loop if we timed out
+        SetErrorBaton(b);
         looping = false;
         break;
       case RdKafka::ERR_NO_ERROR:


### PR DESCRIPTION
This is a proposal for a fix to #401. It forwards consumption time-out errors to the Node.js `KafkaConsumer`, which lets `KafkaConsumerStream` handle it and back off consumption. A couple of notes:

- Before `ERR__TIMED_OUT` and `ERR__TIMED_OUT_QUEUE` were caught and never made it to Node, meaning `KafkaConsumer.consume` could now return an error for code where it didn't before. This could be interpreted as a breaking change.
- To implement the exponential back-off I've added [`retry`](https://www.npmjs.com/package/retry) as a dependency. That was mostly to focus on the effect of the back-off, rather than implementing an effective back-off mechanism (which, [as this article describes well](http://dthain.blogspot.com.au/2009/02/exponential-backoff-in-distributed.html), isn't totally trivial). 
- While it's solved the issue for which I created #401, this back-off is rather "blind". It doesn't use the [`throttleTime` ](https://cwiki.apache.org/confluence/display/KAFKA/KIP-13+-+Quotas#KIP-13-Quotas-PublicInterfaces) field as returned by the Broker. If anyone has some good concrete ideas about how to incorporate that, I'm all ears, because it would be a lot more effective.