### PR TITLE
Add typescript definition overload for both consumer modes.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ export class KafkaConsumer extends Client {
 
     committed(toppars: any, timeout: any, cb: any, ...args: any[]): any;
 
-    consume(number: any, cb: any): void;
+    consume(number: any, cb?: any): void;
     consume(): void;
 
     getWatermarkOffsets(topic: any, partition: any): any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,7 @@ export class KafkaConsumer extends Client {
     committed(toppars: any, timeout: any, cb: any, ...args: any[]): any;
 
     consume(number: any, cb: any): void;
+    consume(): void;
 
     getWatermarkOffsets(topic: any, partition: any): any;
 


### PR DESCRIPTION
Previously only supported the non-flowing option and would complain
that arguments were missing.

This allows TS to compile when using flowing mode