### PR TITLE
Don't require KafkaConsumer to be subscribed to pause and resume the consumption of toppars

### DIFF
--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -358,7 +358,7 @@ Baton KafkaConsumer::Unsubscribe() {
 }
 
 Baton KafkaConsumer::Pause(std::vector<RdKafka::TopicPartition*> & toppars) {
-  if (IsConnected() && IsSubscribed()) {
+  if (IsConnected()) {
     RdKafka::KafkaConsumer* consumer =
       dynamic_cast<RdKafka::KafkaConsumer*>(m_client);
     RdKafka::ErrorCode err = consumer->pause(toppars);
@@ -370,7 +370,7 @@ Baton KafkaConsumer::Pause(std::vector<RdKafka::TopicPartition*> & toppars) {
 }
 
 Baton KafkaConsumer::Resume(std::vector<RdKafka::TopicPartition*> & toppars) {
-  if (IsConnected() && IsSubscribed()) {
+  if (IsConnected()) {
     RdKafka::KafkaConsumer* consumer =
       dynamic_cast<RdKafka::KafkaConsumer*>(m_client);
     RdKafka::ErrorCode err = consumer->resume(toppars);


### PR DESCRIPTION
I ran into this limitation while trying to use `consumer.pause` with a `KafkaConsumer` that isn't subscribed to a Consumer Group, but assigned toppars manually. In neither rdkafka's or the original Java implementation and documentation can I find anything to suggest that this should prevent the use of these control flow methods, but I'm happy to hear what I'm missing :)