### PR TITLE
feat: Using relative paths in builds

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -122,10 +122,10 @@
                   'xcode_settings': {
                     'MACOSX_DEPLOYMENT_TARGET': '10.11',
                     'GCC_ENABLE_CPP_RTTI': 'YES',
-                    'LDFLAGS': [
+                    'OTHER_LDFLAGS': [
                       '-L/usr/local/opt/openssl/lib'
                     ],
-                    'CPLUSPLUSFLAGS': [
+                    'OTHER_CPLUSPLUSFLAGS': [
                       '-I/usr/local/opt/openssl/include',
                       '-std=c++11'
                     ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -37,7 +37,7 @@
                   'librdkafkacpp.lib'
                 ],
                 'AdditionalLibraryDirectories': [
-                  '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/'
+                  'deps/librdkafka/win32/outdir/v120/x64/Release/'
                 ]
               },
               'VCCLCompilerTool': {
@@ -45,7 +45,7 @@
                   '/GR'
                 ],
                 'AdditionalUsingDirectories': [
-                  '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/'
+                  'deps/librdkafka/win32/outdir/v120/x64/Release/'
                 ],
                 'AdditionalIncludeDirectories': [
                   'deps/librdkafka/src-cpp'
@@ -55,7 +55,7 @@
             'msvs_version': '2013',
             'msbuild_toolset': 'v120',
             "dependencies": [
-              "<(module_root_dir)/deps/librdkafka.gyp:librdkafka"
+              "deps/librdkafka.gyp:librdkafka"
             ],
             'include_dirs': [
               'deps/librdkafka/src-cpp'
@@ -66,7 +66,7 @@
               [ "<(BUILD_LIBRDKAFKA)==1",
                 {
                   "dependencies": [
-                    "<(module_root_dir)/deps/librdkafka.gyp:librdkafka"
+                    "deps/librdkafka.gyp:librdkafka"
                   ],
                   "include_dirs": [
                     "deps/librdkafka/src-cpp"
@@ -76,9 +76,9 @@
                       'OS=="linux"',
                       {
                         "libraries": [
-                          "<(module_root_dir)/build/deps/librdkafka.so",
-                          "<(module_root_dir)/build/deps/librdkafka++.so",
-                          "-Wl,-rpath=<(module_root_dir)/build/deps",
+                          "../build/deps/librdkafka.so",
+                          "../build/deps/librdkafka++.so",
+                          "-Wl,-rpath=build/deps",
                         ],
                       }
                     ],
@@ -86,8 +86,8 @@
                       'OS=="mac"',
                       {
                         "libraries": [
-                          "<(module_root_dir)/build/deps/librdkafka.dylib",
-                          "<(module_root_dir)/build/deps/librdkafka++.dylib",
+                          "build/deps/librdkafka.dylib",
+                          "build/deps/librdkafka++.dylib",
                         ],
                       }
                     ]

--- a/deps/librdkafka.gyp
+++ b/deps/librdkafka.gyp
@@ -13,7 +13,7 @@
               {
                 'action_name': 'nuget_restore',
                 'inputs': [
-                  '<(module_root_dir)/deps/librdkafka/win32/librdkafka.sln'
+                  'deps/librdkafka/win32/librdkafka.sln'
                 ],
                 'outputs': [ ],
                 'action': ['nuget', 'restore', '<@(_inputs)']
@@ -21,11 +21,11 @@
               {
                 'action_name': 'build_dependencies',
                 'inputs': [
-                  '<(module_root_dir)/deps/librdkafka/win32/librdkafka.sln'
+                  'deps/librdkafka/win32/librdkafka.sln'
                 ],
                 'outputs': [
-                  '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.lib',
-                  '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.lib'
+                  'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.lib',
+                  'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.lib'
                 ],
                 # Fun story export PATH="$PATH:/c/Program Files (x86)/MSBuild/12.0/Bin/"
                 # I wish there was a better way, but can't find one right now
@@ -35,26 +35,26 @@
             'copies': [
               {
                 'files': [
-                  '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/zlib.dll',
-                  '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.dll',
-                  '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.dll'
+                  'deps/librdkafka/win32/outdir/v120/x64/Release/zlib.dll',
+                  'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.dll',
+                  'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.dll'
                 ],
-                'destination': '<(module_root_dir)/build/Release'
+                'destination': '../build/Release'
               }
             ],
             'libraries': [
-              '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.lib',
-              '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.lib'
+              'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.lib',
+              'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.lib'
             ],
             'build_files': [
-              '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/zlib.dll',
-              '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.dll',
-              '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.dll',
+              'deps/librdkafka/win32/outdir/v120/x64/Release/zlib.dll',
+              'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.dll',
+              'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.dll',
             ],
             'msvs_settings': {
               'VCCLCompilerTool': {
                 'AdditionalUsingDirectories': [
-                  '<(module_root_dir)/deps/librdkafka/win32/outdir/v120/x64/Release/'
+                  'deps/librdkafka/win32/outdir/v120/x64/Release/'
                 ]
               }
             },
@@ -65,39 +65,39 @@
                 "action_name": "configure",
                 "inputs": [],
                 "outputs": [
-                  "<(module_root_dir)/deps/librdkafka/config.h",
+                  "librdkafka/config.h",
                 ],
                 "action": [
-                  "node", "<(module_root_dir)/util/configure"
+                  "node", "../util/configure"
                 ]
               },
               {
                 "action_name": "build_dependencies",
                 "inputs": [
-                  "<(module_root_dir)/deps/librdkafka/config.h",
+                  "librdkafka/config.h",
                 ],
                 "action": [
-                  "make", "-C", "<(module_root_dir)/deps/librdkafka", "libs", "install"
+                  "make", "-C", "librdkafka", "libs", "install"
                 ],
                 "conditions": [
                   [
                     'OS=="mac"',
                     {
                       'outputs': [
-                        '<(module_root_dir)/deps/librdkafka/src-cpp/librdkafka++.dylib',
-                        '<(module_root_dir)/deps/librdkafka/src-cpp/librdkafka++.1.dylib',
-                        '<(module_root_dir)/deps/librdkafka/src/librdkafka.dylib',
-                        '<(module_root_dir)/deps/librdkafka/src/librdkafka.1.dylib'
+                        'deps/librdkafka/src-cpp/librdkafka++.dylib',
+                        'deps/librdkafka/src-cpp/librdkafka++.1.dylib',
+                        'deps/librdkafka/src/librdkafka.dylib',
+                        'deps/librdkafka/src/librdkafka.1.dylib'
                       ],
                     },
                     {
                       'outputs': [
-                        '<(module_root_dir)/deps/librdkafka/src-cpp/librdkafka++.so',
-                        '<(module_root_dir)/deps/librdkafka/src-cpp/librdkafka++.so.1',
-                        '<(module_root_dir)/deps/librdkafka/src/librdkafka.so',
-                        '<(module_root_dir)/deps/librdkafka/src/librdkafka.so.1',
-                        '<(module_root_dir)/deps/librdkafka/src-cpp/librdkafka++.a',
-                        '<(module_root_dir)/deps/librdkafka/src/librdkafka.a',
+                        'deps/librdkafka/src-cpp/librdkafka++.so',
+                        'deps/librdkafka/src-cpp/librdkafka++.so.1',
+                        'deps/librdkafka/src/librdkafka.so',
+                        'deps/librdkafka/src/librdkafka.so.1',
+                        'deps/librdkafka/src-cpp/librdkafka++.a',
+                        'deps/librdkafka/src/librdkafka.a',
                       ],
                     }
                   ]


### PR DESCRIPTION
Here's me taking a stab at getting relative path builds working in the linux environment in response to portability issues brought up in https://github.com/Blizzard/node-rdkafka/issues/405

This was mostly implemented though guess and check, so I am more than open to feedback. I got rid of every instance of `<(module_root_dir)/` except for the one in the `include` (which I couldn't get to pass without it).

I'm not sure which paths could be absolute, which need to be relative, but I wanted to get the ball rolling so I converted everything I could.

The mac build we'll have to iterate on with travis since I only have access to a linux environment