### PR TITLE
Move error handling of `Consumer.consume` timeouts to Node and allow to disable

### DIFF
--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -449,7 +449,7 @@ KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, options, 
       if (cb) {
         if (
           !options.timeoutErrors && 
-          (ErrorCode.ERR__TIMED_OUT !== err.code || ErrorCode.ERR__TIMED_OUT_QUEUE !== err.code)
+          (ErrorCode.ERR__TIMED_OUT === err.code || ErrorCode.ERR__TIMED_OUT_QUEUE === err.code)
         ) {
           cb(null, []);
         } else {

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -15,6 +15,7 @@ var util = require('util');
 var Kafka = require('../librdkafka');
 var KafkaConsumerStream = require('./kafka-consumer-stream');
 var LibrdKafkaError = require('./error');
+var ErrorCode = LibrdKafkaError.codes;
 var TopicPartition = require('./topic-partition');
 
 util.inherits(KafkaConsumer, Client);
@@ -362,9 +363,13 @@ KafkaConsumer.prototype.unsubscribe = function() {
  * @param {KafkaConsumer~readCallback} cb - Callback to return when a message
  * is fetched.
  */
-KafkaConsumer.prototype.consume = function(number, cb) {
+KafkaConsumer.prototype.consume = function(number, options, cb) {
   var timeoutMs = this._consumeTimeout || 1000;
   var self = this;
+  if (typeof options === 'function' && !cb) {
+    cb = options;
+    options = {};
+  }
 
   if ((number && typeof number === 'number') || (number && cb)) {
 
@@ -374,7 +379,7 @@ KafkaConsumer.prototype.consume = function(number, cb) {
       throw new TypeError('Callback must be a function');
     }
 
-    this._consumeNum(timeoutMs, number, cb);
+    this._consumeNum(timeoutMs, number, options, cb);
   } else {
 
     // See https://github.com/Blizzard/node-rdkafka/issues/220
@@ -434,14 +439,23 @@ KafkaConsumer.prototype._consumeLoop = function(timeoutMs, cb) {
  * @private
  * @see consume
  */
-KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, cb) {
+KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, options, cb) {
   var self = this;
 
   this._client.consume(timeoutMs, numMessages, function(err, messages) {
     if (err) {
       err = LibrdKafkaError.create(err);
+
       if (cb) {
-        cb(err);
+        if (
+          !options.timeoutErrors && 
+          (ErrorCode.ERR__TIMED_OUT !== err.code || ErrorCode.ERR__TIMED_OUT_QUEUE !== err.code)
+        ) {
+          cb(null, []);
+        } else {
+          cb(err);
+
+        }
       }
       return;
     }

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -533,6 +533,7 @@ void KafkaConsumerConsumeNum::Execute() {
       case RdKafka::ERR__TIMED_OUT:
       case RdKafka::ERR__TIMED_OUT_QUEUE:
         // Break of the loop if we timed out
+        SetErrorBaton(b);
         looping = false;
         break;
       case RdKafka::ERR_NO_ERROR:


### PR DESCRIPTION
Finally I had the opportunity to follow up on discussions about #404. By moving the error handling logic for consuming a number of messages to the Node layer, it can be further controlled to implement such things are exponential back-off when being throttled by the Broker.

In order to not introduce any breaking changes I added an optional `options` argument to `consumer.consume`. The `timeoutErrors` option can be set to a true to prevent time-out errors from being handled, so the caller can handle those themselves. By default they are ignored and return an empty array of messages instead.