### PR TITLE
Migrate to v0.11.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Copyright (c) 2016 Blizzard Entertainment.
 
 The `node-rdkafka` library is a high-performance NodeJS client for [Apache Kafka](http://kafka.apache.org/) that wraps the native  [librdkafka](https://github.com/edenhill/librdkafka) library.  All the complexity of balancing writes across partitions and managing (possibly ever-changing) brokers should be encapsulated in the library.
 
-__This library currently uses `librdkafka` version `0.11.4`.__
+__This library currently uses `librdkafka` version `0.11.5`.__
 
 ## Reference Docs
 


### PR DESCRIPTION
A couple of days ago [v0.11.5 was released](https://github.com/edenhill/librdkafka/releases/tag/v0.11.5). Most notably, it brings support for [KIP-4](https://cwiki.apache.org/confluence/display/KAFKA/KIP-4+-+Command+line+and+centralized+administrative+operations) (the Admin API), but also a list of bug fixes.