### PR TITLE
Use Buffer.from instead of new Buffer()

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ var stream = Kafka.Producer.createWriteStream({
 });
 
 // Writes a message to the stream
-var queuedSuccess = stream.write(new Buffer('Awesome message'));
+var queuedSuccess = stream.write(Buffer.from('Awesome message'));
 
 if (queuedSuccess) {
   console.log('We queued our message!');
@@ -225,7 +225,7 @@ producer.on('ready', function() {
       // this defaults to -1 - which will use librdkafka's default partitioner (consistent random for keyed messages, random for unkeyed messages)
       null,
       // Message to send. Must be a buffer
-      new Buffer('Awesome message'),
+      Buffer.from('Awesome message'),
       // for keyed messages, we also specify the key - note that this field is optional
       'Stormwind',
       // you can send a timestamp here. If your broker version supports it,
@@ -372,7 +372,7 @@ Messages that are returned by the `KafkaConsumer` have the following structure.
 
 ```js
 {
-  value: new Buffer('hi'), // message contents as a Buffer
+  value: Buffer.from('hi'), // message contents as a Buffer
   size: 2, // size of the message, in bytes
   topic: 'librdtesting-01', // topic the message comes from
   offset: 1337, // offset the message was read from

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -243,7 +243,7 @@ describe('Consumer/Producer', function() {
   it('should be able to produce and consume messages: empty key and empty value', function(done) {
     this.timeout(20000);
     var key = '';
-    var value = new Buffer('');
+    var value = Buffer.from('');
 
     producer.setPollInterval(10);
 
@@ -319,7 +319,7 @@ describe('Consumer/Producer', function() {
     it('should async commit after consuming', function(done) {
       this.timeout(25000);
       var key = '';
-      var value = new Buffer('');
+      var value = Buffer.from('');
 
       var lastOffset = null;
 
@@ -398,7 +398,7 @@ describe('Consumer/Producer', function() {
         consumer.subscribe([topic]);
         consumer.consume();
         setTimeout(function() {
-          producer.produce(topic, null, new Buffer(''), '');
+          producer.produce(topic, null, Buffer.from(''), '');
         }, 2000);
       });
 

--- a/e2e/groups.spec.js
+++ b/e2e/groups.spec.js
@@ -71,7 +71,7 @@ describe('Consumer group/Producer', function() {
     this.timeout(30000);
     var topic = 'test';
     var key = 'key';
-    var payload = new Buffer('value');
+    var payload = Buffer.from('value');
     var count = 0;
     var offsets = {
       'first': true

--- a/e2e/producer.spec.js
+++ b/e2e/producer.spec.js
@@ -98,7 +98,7 @@ describe('Producer', function() {
         done();
       });
 
-      producer.produce('test', null, new Buffer('value'), 'key');
+      producer.produce('test', null, Buffer.from('value'), 'key');
     });
 
     it('should produce a message with a payload and key buffer', function(done) {
@@ -120,7 +120,7 @@ describe('Producer', function() {
         done();
       });
 
-      producer.produce('test', null, new Buffer('value'), new Buffer('key\0s'));
+      producer.produce('test', null, Buffer.from('value'), Buffer.from('key\0s'));
     });
 
     it('should produce a message with an opaque', function(done) {
@@ -141,7 +141,7 @@ describe('Producer', function() {
         done();
       });
 
-      producer.produce('test', null, new Buffer('value'), null, null, 'opaque');
+      producer.produce('test', null, Buffer.from('value'), null, null, 'opaque');
     });
 
 
@@ -172,7 +172,7 @@ describe('Producer', function() {
 
       // Produce
       for (total = 0; total <= max; total++) {
-        producer.produce('test', null, new Buffer('message ' + total), null);
+        producer.produce('test', null, Buffer.from('message ' + total), null);
       }
 
     });
@@ -220,7 +220,7 @@ describe('Producer', function() {
         done();
       });
 
-      producer.produce('test', null, new Buffer('hai'), 'key');
+      producer.produce('test', null, Buffer.from('hai'), 'key');
     });
 
     it('should produce a message with an empty payload and empty key (https://github.com/Blizzard/node-rdkafka/issues/117)', function(done) {
@@ -243,7 +243,7 @@ describe('Producer', function() {
         done();
       });
 
-      producer.produce('test', null, new Buffer(''), '');
+      producer.produce('test', null, Buffer.from(''), '');
     });
 
     it('should produce a message with a null payload and null key  (https://github.com/Blizzard/node-rdkafka/issues/117)', function(done) {

--- a/examples/producer-cluster.md
+++ b/examples/producer-cluster.md
@@ -52,7 +52,7 @@ if (cluster.isMaster) {
   var sendMessage = function() {
     var ret = producer.sendMessage({
       topic: 'librdtesting-01',
-      message: new Buffer('message ' + total)
+      message: Buffer.from('message ' + total)
     }, function() {
     });
     total++;

--- a/examples/producer.md
+++ b/examples/producer.md
@@ -43,7 +43,7 @@ producer.on('ready', function(arg) {
   console.log('producer ready.' + JSON.stringify(arg));
 
   for (var i = 0; i < maxMessages; i++) {
-    var value = new Buffer('value-' +i);
+    var value = Buffer.from('value-' +i);
     var key = "key-"+i;
     // if partition is set to -1, librdkafka will use the default partitioner
     var partition = -1;

--- a/test/kafka-consumer-stream.spec.js
+++ b/test/kafka-consumer-stream.spec.js
@@ -43,7 +43,7 @@ module.exports = {
           'Provided callback should always be a function');
         setImmediate(function() {
           cb(null, [{
-            value: new Buffer('test'),
+            value: Buffer.from('test'),
             key: 'testkey',
             offset: 1
           }]);
@@ -151,7 +151,7 @@ module.exports = {
           numSent++;
           setImmediate(function() {
             cb(null, [{
-              value: new Buffer('test'),
+              value: Buffer.from('test'),
               offset: 1
             }]);
           });
@@ -209,7 +209,7 @@ module.exports = {
           numSent++;
           setImmediate(function() {
             cb(null, [{
-              value: new Buffer('test'),
+              value: Buffer.from('test'),
               offset: 1
             }]);
           });
@@ -250,7 +250,7 @@ module.exports = {
           numSent++;
           setImmediate(function() {
             cb(null, [{
-              value: new Buffer('test'),
+              value: Buffer.from('test'),
               offset: 1
             }]);
           });

--- a/test/producer-stream.spec.js
+++ b/test/producer-stream.spec.js
@@ -148,7 +148,7 @@ module.exports = {
           t.fail(err);
         });
 
-        stream.write(new Buffer('Awesome'));
+        stream.write(Buffer.from('Awesome'));
       },
 
       'passes a topic string if options are not provided': function(done) {
@@ -168,7 +168,7 @@ module.exports = {
           t.fail(err);
         });
 
-        stream.write(new Buffer('Awesome'));
+        stream.write(Buffer.from('Awesome'));
       },
 
       'properly handles queue errors': function(done) {
@@ -197,7 +197,7 @@ module.exports = {
           t.fail(err);
         });
 
-        stream.write(new Buffer('Awesome'));
+        stream.write(Buffer.from('Awesome'));
       },
 
       'errors out when a non-queue related error occurs': function(done) {
@@ -219,7 +219,7 @@ module.exports = {
           // This is good
         });
 
-        stream.write(new Buffer('Awesome'));
+        stream.write(Buffer.from('Awesome'));
       },
 
       'errors out when a non-queue related error occurs but does not disconnect if autoclose is false': function(done) {
@@ -242,7 +242,7 @@ module.exports = {
           // This is good
         });
 
-        stream.write(new Buffer('Awesome'));
+        stream.write(Buffer.from('Awesome'));
 
         setTimeout(done, 10);
       },
@@ -269,8 +269,8 @@ module.exports = {
           t.fail(err);
         });
 
-        stream.write(new Buffer('Awesome1'));
-        stream.write(new Buffer('Awesome2'));
+        stream.write(Buffer.from('Awesome1'));
+        stream.write(Buffer.from('Awesome2'));
       },
 
       'can be piped into a readable': function(done) {
@@ -338,9 +338,9 @@ module.exports = {
           return false;
         };
 
-        stream.write(new Buffer('Awesome1'));
-        stream.write(new Buffer('Awesome2'));
-        stream.write(new Buffer('Awesome3'));
+        stream.write(Buffer.from('Awesome1'));
+        stream.write(Buffer.from('Awesome2'));
+        stream.write(Buffer.from('Awesome3'));
 
         fakeClient._isConnected = true;
         fakeClient._isConnecting = false;
@@ -384,7 +384,7 @@ module.exports = {
 
         stream.write({
           topic: 'topic',
-          value: new Buffer('Awesome'),
+          value: Buffer.from('Awesome'),
           partition: 10,
           key: 'key',
           timestamp: _timestamp,
@@ -422,7 +422,7 @@ module.exports = {
 
         stream.write({
           topic: 'topic',
-          value: new Buffer('Awesome'),
+          value: Buffer.from('Awesome'),
           partition: 10,
           key: 'key'
         });
@@ -447,7 +447,7 @@ module.exports = {
           // This is good
         });
 
-        stream.write(new Buffer('Awesome'));
+        stream.write(Buffer.from('Awesome'));
       },
 
       'errors out when a non-queue related error occurs but does not disconnect if autoclose is false': function(done) {
@@ -471,7 +471,7 @@ module.exports = {
         });
 
         stream.write({
-          value: new Buffer('Awesome'),
+          value: Buffer.from('Awesome'),
           topic: 'topic'
         });
 
@@ -501,11 +501,11 @@ module.exports = {
         });
 
         stream.write({
-          value: new Buffer('Awesome1'),
+          value: Buffer.from('Awesome1'),
           topic: 'topic'
         });
         stream.write({
-          value: new Buffer('Awesome2'),
+          value: Buffer.from('Awesome2'),
           topic: 'topic'
         });
       },
@@ -525,11 +525,11 @@ module.exports = {
             } else {
               this.push({
                 topic: 'topic',
-                value: new Buffer('Awesome1')
+                value: Buffer.from('Awesome1')
               });
               this.push({
                 topic: 'topic',
-                value: new Buffer('Awesome2')
+                value: Buffer.from('Awesome2')
               });
             }
           }
@@ -584,15 +584,15 @@ module.exports = {
         };
 
         stream.write({
-          value: new Buffer('Awesome1'),
+          value: Buffer.from('Awesome1'),
           topic: 'topic'
         });
         stream.write({
-          value: new Buffer('Awesome2'),
+          value: Buffer.from('Awesome2'),
           topic: 'topic'
         });
         stream.write({
-          value: new Buffer('Awesome3'),
+          value: Buffer.from('Awesome3'),
           topic: 'topic'
         });
 
@@ -633,19 +633,19 @@ module.exports = {
         };
 
         stream.write({
-          value: new Buffer('Awesome1'),
+          value: Buffer.from('Awesome1'),
           topic: 'topic'
         });
         stream.write({
-          value: new Buffer('Awesome2'),
+          value: Buffer.from('Awesome2'),
           topic: 'topic'
         });
         stream.write({
-          value: new Buffer('Awesome3'),
+          value: Buffer.from('Awesome3'),
           topic: 'topic'
         });
         stream.write({
-          value: new Buffer('Awesome4'),
+          value: Buffer.from('Awesome4'),
           topic: 'topic'
         });
 
@@ -688,19 +688,19 @@ module.exports = {
         };
 
         stream.write({
-          value: new Buffer('Awesome1'),
+          value: Buffer.from('Awesome1'),
           topic: 'topic'
         });
         stream.write({
-          value: new Buffer('Awesome2'),
+          value: Buffer.from('Awesome2'),
           topic: 'topic'
         });
         stream.write({
-          value: new Buffer('Awesome3'),
+          value: Buffer.from('Awesome3'),
           topic: 'topic'
         });
         stream.write({
-          value: new Buffer('Awesome4'),
+          value: Buffer.from('Awesome4'),
           topic: 'topic'
         });
 


### PR DESCRIPTION
Node 4 is EOL since April 2018, and since 6 `new Buffer()` is deprecated.  I suggest to drop support for node 4. If 4 is required probably some polyfill can be used (https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/).