### PR TITLE
Updated mocha + small code changes for cpplint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ check: node_modules/.dirstamp
 	@$(NODE) util/test-compile.js
 
 e2e: $(E2E_TESTS)
-	@./node_modules/.bin/mocha $(TEST_REPORTER) $(E2E_TESTS) $(TEST_OUTPUT)
+	@./node_modules/.bin/mocha --exit $(TEST_REPORTER) $(E2E_TESTS) $(TEST_OUTPUT)
 
 define release
 	NEXT_VERSION=$(shell node -pe 'require("semver").inc("$(VERSION)", "$(1)")')

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then you can run `npm install` on your application to get it to build correctly.
 
 __NOTE:__ From the `librdkafka` docs
 
-> WARNING: Due to a bug in Apache Kafka 0.9.0.x, the ApiVersionRequest (as sent by the client when connecting to the broker) will be silently ignored by the broker causing the request to time out after 10 seconds. This causes client-broker connections to stall for 10 seconds during connection-setup before librdkafka falls back on the broker.version.fallback protocol features. The workaround is to explicitly configure api.version.request to false on clients communicating with <=0.9.0.x brokers.
+> WARNING: Due to a bug in Apache Kafka 0.9.0.x, the ApiVersionRequest (as sent by the client when connecting to the broker) will be silently ignored by the broker causing the request to time out after 10 seconds. This causes client-broker connections to stall for 10 seconds during connection-setup before librdkafka falls back on the `broker.version.fallback` protocol features. The workaround is to explicitly configure `api.version.request` to `false` on clients communicating with <=0.9.0.x brokers.
 
 ### Alpine
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jshint": "2.x",
     "jsdoc": "^3.4.0",
     "toolkit-jsdoc": "^1.0.0",
-    "mocha": "2.x",
+    "mocha": "^5.2.0",
     "node-gyp": "3.x"
   },
   "dependencies": {

--- a/src/admin.cc
+++ b/src/admin.cc
@@ -212,56 +212,56 @@ void AdminClient::DeactivateDispatchers() {
  * C++ Exported prototype functions
  */
 
- NAN_METHOD(AdminClient::NodeConnect) {
-   Nan::HandleScope scope;
+NAN_METHOD(AdminClient::NodeConnect) {
+  Nan::HandleScope scope;
 
-   AdminClient* client = ObjectWrap::Unwrap<AdminClient>(info.This());
+  AdminClient* client = ObjectWrap::Unwrap<AdminClient>(info.This());
 
-   Baton b = client->Connect();
-   // Let the JS library throw if we need to so the error can be more rich
-   int error_code = static_cast<int>(b.err());
-   return info.GetReturnValue().Set(Nan::New<v8::Number>(error_code));
- }
+  Baton b = client->Connect();
+  // Let the JS library throw if we need to so the error can be more rich
+  int error_code = static_cast<int>(b.err());
+  return info.GetReturnValue().Set(Nan::New<v8::Number>(error_code));
+}
 
- NAN_METHOD(AdminClient::NodeDisconnect) {
-   Nan::HandleScope scope;
+NAN_METHOD(AdminClient::NodeDisconnect) {
+  Nan::HandleScope scope;
 
-   AdminClient* client = ObjectWrap::Unwrap<AdminClient>(info.This());
+  AdminClient* client = ObjectWrap::Unwrap<AdminClient>(info.This());
 
-   Baton b = client->Disconnect();
-   // Let the JS library throw if we need to so the error can be more rich
-   int error_code = static_cast<int>(b.err());
-   return info.GetReturnValue().Set(Nan::New<v8::Number>(error_code));
- }
+  Baton b = client->Disconnect();
+  // Let the JS library throw if we need to so the error can be more rich
+  int error_code = static_cast<int>(b.err());
+  return info.GetReturnValue().Set(Nan::New<v8::Number>(error_code));
+}
 
 /**
  * Create topic
  */
 NAN_METHOD(AdminClient::NodeCreateTopic) {
-   Nan::HandleScope scope;
+  Nan::HandleScope scope;
 
-   if (info.Length() < 2 || !info[1]->IsFunction()) {
-     // Just throw an exception
-     return Nan::ThrowError("Need to specify a callback");
-   }
+  if (info.Length() < 2 || !info[1]->IsFunction()) {
+    // Just throw an exception
+    return Nan::ThrowError("Need to specify a callback");
+  }
 
-   v8::Local<v8::Function> cb = info[1].As<v8::Function>();
-   Nan::Callback *callback = new Nan::Callback(cb);
-   AdminClient* client = ObjectWrap::Unwrap<AdminClient>(info.This());
+  v8::Local<v8::Function> cb = info[1].As<v8::Function>();
+  Nan::Callback *callback = new Nan::Callback(cb);
+  AdminClient* client = ObjectWrap::Unwrap<AdminClient>(info.This());
 
-   std::string errstr;
-   // Get that topic we want to create
-   rd_kafka_NewTopic_t* topic = Conversion::Admin::FromV8TopicObject(info[0].As<v8::Object>(), errstr);
+  std::string errstr;
+  // Get that topic we want to create
+  rd_kafka_NewTopic_t* topic = Conversion::Admin::FromV8TopicObject(info[0].As<v8::Object>(), errstr);
 
-   if (topic == NULL) {
-     Nan::ThrowError(errstr.c_str());
-     return;
-   }
+  if (topic == NULL) {
+    Nan::ThrowError(errstr.c_str());
+    return;
+  }
 
-   // Queue up dat work
-   Nan::AsyncQueueWorker(new Workers::AdminClientCreateTopic(callback, client, topic, 1000));
+  // Queue up dat work
+  Nan::AsyncQueueWorker(new Workers::AdminClientCreateTopic(callback, client, topic, 1000));
 
-   return info.GetReturnValue().Set(Nan::Null());
- }
+  return info.GetReturnValue().Set(Nan::Null());
+}
 
 }  // namespace NodeKafka

--- a/src/admin.h
+++ b/src/admin.h
@@ -52,13 +52,12 @@ class AdminClient : public Connection {
   static Nan::Persistent<v8::Function> constructor;
   static void New(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
-  AdminClient(Conf* globalConfig);
+  explicit AdminClient(Conf* globalConfig);
   ~AdminClient();
 
   rd_kafka_queue_t* rkqu;
 
  private:
-
   // Node methods
   static NAN_METHOD(NodeValidateTopic);
   static NAN_METHOD(NodeCreateTopic);

--- a/src/common.cc
+++ b/src/common.cc
@@ -474,8 +474,7 @@ rd_kafka_NewTopic_t* FromV8TopicObject(v8::Local<v8::Object> object, std::string
     num_partitions,
     replication_factor,
     errbuf,
-    errstr_size
-  );
+    errstr_size);
 
   if (new_topic == NULL) {
     errstr = std::string(errbuf, errstr_size);
@@ -532,7 +531,7 @@ rd_kafka_NewTopic_t** FromV8TopicObjectArray(v8::Local<v8::Array>) {
   return NULL;
 }
 
-}
+}  // namespace Admin
 
 }  // namespace Conversion
 

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -713,7 +713,7 @@ void KafkaConsumerCommitted::HandleErrorCallback() {
  *
  * @see RdKafka::KafkaConsumer::seek
  *
- * @remark Consumtion for the given partition must have started for the
+ * @remark Consumption for the given partition must have started for the
  *         seek to work. Use assign() to set the starting offset.
  */
 
@@ -768,15 +768,10 @@ void KafkaConsumerSeek::HandleErrorCallback() {
 }
 
 /**
- * @brief  seek
+ * @brief createTopic
  *
- * This callback will take a topic partition list with offsets and
- * seek messages from there
+ * This callback will create a topic
  *
- * @see RdKafka::KafkaConsumer::seek
- *
- * @remark Consumtion for the given partition must have started for the
- *         seek to work. Use assign() to set the starting offset.
  */
 
 AdminClientCreateTopic::AdminClientCreateTopic(Nan::Callback *callback,


### PR DESCRIPTION
- `npm audit` reports security issues with mocha 2.x. I used `npm audit fix --force` to update the `package.json` file automatically.

    However since mocha 4, `process.exit()` is not called automatically and `make e2e` was not terminating once all tests had passed. So it looks like some resources are not currently closed properly. It's something we should fix but in the meantime I've added the `--exit` flag to force the previous behavior (https://boneskull.com/mocha-v4-nears-release/#mochawontforceexit).

- `make lint` also has a number of issues and I fixed the low hanging fruits.

- Minor code/README fixes

