### PR TITLE
connection.failure error emit

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -175,7 +175,7 @@ Client.prototype.connect = function(metadataOptions, cb) {
         next(err); return;
       }, 10000).unref();
 
-      self.emit('connection.failure', self.metrics);
+      self.emit('connection.failure', err, self.metrics);
     } else {
 
       next(err);


### PR DESCRIPTION
Currently emitting `self.metrics` which is an empty object before the connection has been created and gobbling the librdkafka error, so it's pretty useless for figuring out what happened.