### PR TITLE
test: Add retry test case

### DIFF
--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -285,7 +285,7 @@ describe('Consumer/Producer', function() {
 
   it('should be able to produce and consume messages: after an error', function(done) {
     this.timeout(20000);
-
+    var grp = 'kafka-mocha-grp-' + crypto.randomBytes(20).toString('hex');
     var consumerOpts = {
         'metadata.broker.list': kafkaBrokerList,
         'group.id': grp,

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -314,8 +314,6 @@ describe('Consumer/Producer', function() {
       if (count == 2) {
         consumer.commitMessage(message);
         done();
-      } else {
-        throw Error('We had an error, this message should retry');
       }
     });
   });


### PR DESCRIPTION
Basically testing if this sort of behavior is supported. If not what are our alternatives when an error occurs (or no commit occurs) in the 'data' event handler.
@webmakersteve  any thoughts on how to tell the library that the consumption of this message failed, and lets try again?