### PR TITLE
Fix wrong relative path and build directories in Windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -38,7 +38,7 @@
                   'librdkafkacpp.lib'
                 ],
                 'AdditionalLibraryDirectories': [
-                  'deps/librdkafka/win32/outdir/v120/x64/Release/'
+                  '../deps/librdkafka/win32/outdir/v120/x64/Release/'
                 ]
               },
               'VCCLCompilerTool': {
@@ -46,11 +46,11 @@
                   '/GR'
                 ],
                 'AdditionalUsingDirectories': [
-                  'deps/librdkafka/win32/outdir/v120/x64/Release/'
+                  '../deps/librdkafka/win32/outdir/v120/x64/Release/'
                 ],
                 'AdditionalIncludeDirectories': [
-                  'deps/librdkafka/src',
-                  'deps/librdkafka/src-cpp'
+                  '../deps/librdkafka/src',
+                  '../deps/librdkafka/src-cpp'
                 ]
               }
             },
@@ -60,8 +60,8 @@
               "deps/librdkafka.gyp:librdkafka"
             ],
             'include_dirs': [
-              'deps/librdkafka/src',
-              'deps/librdkafka/src-cpp'
+              '../deps/librdkafka/src',
+              '../deps/librdkafka/src-cpp'
             ]
           },
           {

--- a/deps/librdkafka.gyp
+++ b/deps/librdkafka.gyp
@@ -12,20 +12,18 @@
             'actions': [
               {
                 'action_name': 'nuget_restore',
-                'inputs': [
-                  'deps/librdkafka/win32/librdkafka.sln'
-                ],
+                'inputs': [ ],
                 'outputs': [ ],
-                'action': ['nuget', 'restore', '<@(_inputs)']
+                'action': ['nuget.exe', 'restore', 'librdkafka/win32/librdkafka.sln']
               },
               {
                 'action_name': 'build_dependencies',
                 'inputs': [
-                  'deps/librdkafka/win32/librdkafka.sln'
+                  'librdkafka/win32/librdkafka.sln'
                 ],
                 'outputs': [
-                  'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.lib',
-                  'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.lib'
+                  'librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.lib',
+                  'librdkafka/win32/outdir/v120/x64/Release/librdkafka.lib'
                 ],
                 # Fun story export PATH="$PATH:/c/Program Files (x86)/MSBuild/12.0/Bin/"
                 # I wish there was a better way, but can't find one right now
@@ -35,26 +33,26 @@
             'copies': [
               {
                 'files': [
-                  'deps/librdkafka/win32/outdir/v120/x64/Release/zlib.dll',
-                  'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.dll',
-                  'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.dll'
+                  'librdkafka/win32/outdir/v120/x64/Release/zlib.dll',
+                  'librdkafka/win32/outdir/v120/x64/Release/librdkafka.dll',
+                  'librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.dll'
                 ],
                 'destination': '../build/Release'
               }
             ],
             'libraries': [
-              'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.lib',
-              'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.lib'
+              'librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.lib',
+              'librdkafka/win32/outdir/v120/x64/Release/librdkafka.lib'
             ],
             'build_files': [
-              'deps/librdkafka/win32/outdir/v120/x64/Release/zlib.dll',
-              'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.dll',
-              'deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.dll',
+              'librdkafka/win32/outdir/v120/x64/Release/zlib.dll',
+              'librdkafka/win32/outdir/v120/x64/Release/librdkafka.dll',
+              'librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.dll',
             ],
             'msvs_settings': {
               'VCCLCompilerTool': {
                 'AdditionalUsingDirectories': [
-                  'deps/librdkafka/win32/outdir/v120/x64/Release/'
+                  'librdkafka/win32/outdir/v120/x64/Release/'
                 ]
               }
             },


### PR DESCRIPTION
Build on master branch get these error:
```
Warning: Missing input files:
Y:\node-rdkafka\build\deps\..\..\deps\deps\librdkafka\win32\outdir\v120\x64\Release\zlib.dll
Y:\node-rdkafka\build\deps\..\..\deps\deps\librdkafka\win32\outdir\v120\x64\Release\librdkafkacpp.dll
Y:\node-rdkafka\build\deps\..\..\deps\deps\librdkafka\win32\outdir\v120\x64\Release\librdkafka.dll
Y:\node-rdkafka\build\deps\..\..\deps\deps\librdkafka\win32\librdkafka.sln
gyp verb command build []
gyp verb build type Release
gyp verb architecture x64
gyp verb node dev dir C:\Users\deliay\.node-gyp\8.11.2
gyp verb found first Solution file build/binding.sln
gyp verb `which` succeeded for `msbuild` C:\Program Files (x86)\MSBuild\12.0\Bin\msbuild.EXE
gyp info spawn msbuild
gyp info spawn args [ 'build/binding.sln',
gyp info spawn args   '/nologo',
gyp info spawn args   '/p:Configuration=Release;Platform=x64' ]
Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.
Build started 11/30/2018 9:30:27 AM.
Project "Y:\node-rdkafka\build\binding.sln" on node 1 (default targets).
ValidateSolutionConfiguration:
  Building solution configuration "Release|x64".
Project "Y:\node-rdkafka\build\binding.sln" (1) is building "Y:\node-rdkafka\build\deps\librdkafka.vcxproj" (2) on node 1 (default targets).
PrepareForBuild:
  Creating directory "Release\obj\librdkafka\".
  Creating directory "Y:\node-rdkafka\build\Release\".
  Creating directory "Release\obj\librdkafka\librdkafka.tlog\".
InitializeBuildStatus:
  Creating "Release\obj\librdkafka\librdkafka.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
ComputeCustomBuildOutput:
  Creating directory "Y:\node-rdkafka\deps\deps\librdkafka\win32\outdir\v120\x64\Release\".
CustomBuild:
  Copying deps/librdkafka/win32/outdir/v120/x64/Release/librdkafkacpp.dll to ../build/Release\librdkafkacpp.dll
  The system cannot find the file specified.
  Copying deps/librdkafka/win32/outdir/v120/x64/Release/librdkafka.dll to ../build/Release\librdkafka.dll
  The system cannot find the file specified.
  nuget_restore, and also build_dependencies
  Unknown command: '..\..\deps\restore'
  NuGet.CommandLine.CommandLineException: Unknown command: '..\..\deps\restore'
     at NuGet.CommandLine.CommandManager.GetCommand(String commandName)
     at NuGet.CommandLine.CommandLineParser.ParseCommandLine(IEnumerable`1 commandLineArgs)
     at NuGet.CommandLine.Program.MainCore(String workingDirectory, String[] args)
  Microsoft (R) Build Engine version 12.0.40629.0
  [Microsoft .NET Framework, version 4.0.30319.42000]
  Copyright (C) Microsoft Corporation. All rights reserved.

MSBUILD : error MSB1009: Project file does not exist. [Y:\node-rdkafka\build\deps\librdkafka.vcxproj]
  Switch: ..\..\deps\deps\librdkafka\win32\librdkafka.sln
  Copying deps/librdkafka/win32/outdir/v120/x64/Release/zlib.dll to ../build/Release\zlib.dll
  The system cannot find the file specified.
Done Building Project "Y:\node-rdkafka\build\deps\librdkafka.vcxproj" (default targets) -- FAILED.

Done Building Project "Y:\node-rdkafka\build\binding.sln" (default targets) -- FAILED.


Build FAILED.
```

Seem wrong relative path was given to builder, like:
```
  nuget_restore, and also build_dependencies
  Unknown command: '..\..\deps\restore'
  NuGet.CommandLine.CommandLineException: Unknown command: '..\..\deps\restore'
```

and
```
Warning: Missing input files:
Y:\node-rdkafka\build\deps\..\..\deps\deps\librdkafka\win32\outdir\v120\x64\Release\zlib.dll
Y:\node-rdkafka\build\deps\..\..\deps\deps\librdkafka\win32\outdir\v120\x64\Release\librdkafkacpp.dll
Y:\node-rdkafka\build\deps\..\..\deps\deps\librdkafka\win32\outdir\v120\x64\Release\librdkafka.dll
Y:\node-rdkafka\build\deps\..\..\deps\deps\librdkafka\win32\librdkafka.sln
```

Test fix:
Delete `./deps/librdkafka/win32/outdir`
Delete `./deps/librdkafka/win32/interim`
Delete `./build`
Run `npm install`

Success in node v8.11.2, npm 6.1.0, node-gyp v3.8.0
![20181130103553](https://user-images.githubusercontent.com/5661435/49265090-c22a8c80-f48b-11e8-89e1-ed626a88b52c.png)
