### PR TITLE
Fix Bug #474

### DIFF
--- a/util/configure.js
+++ b/util/configure.js
@@ -9,6 +9,8 @@ var baseDir = path.resolve(__dirname, '../');
 var releaseDir = path.join(baseDir, 'build', 'deps');
 
 var isWin = /^win/.test(process.platform);
+var isLinux = /linux/.test(process.platform);
+var ENVVARS = ""
 
 // Skip running this if we are running on a windows system
 if (isWin) {
@@ -16,10 +18,16 @@ if (isWin) {
   process.exit(0);
 }
 
+//for linux we want to ensure we'll find the desired libkafka.so.1 file. To do this we'are going to tell librdkafka++.so.1 to look in its current path at runtime as an additional location to search for libraries.
+else if (isLinux) {
+  ENVVARS = isLinux ? "LDFLAGS='-Wl,-rpath,\\\$$ORIGIN' " : ""
+}
+
+
 var childProcess = require('child_process');
 
 try {
-  childProcess.execSync('./configure --prefix=' + releaseDir + ' --libdir=' + releaseDir, {
+  childProcess.execSync(ENVVARS +  "./configure --prefix=" + releaseDir + ' --libdir=' + releaseDir, {
     cwd: baseDir,
     stdio: [0,1,2]
   });


### PR DESCRIPTION
Fix librdkafka++.so.1 not searching for librdkafka.so.1 correctly by adjusting the librdkafka++.so.1 build configuration to look in its current directory when loading librdkafka.so.1.
This avoids the issue with librdkafka++.so.1 not finding librdkafka.so.1 when not available in a standard library search path as well as avoiding the loading of an unexpected librdkafka.so.1 version which may be present in a standard library search path.
