### PR TITLE
Return broker error messages for create topic, create partitions

### DIFF
--- a/src/admin.cc
+++ b/src/admin.cc
@@ -236,7 +236,7 @@ Baton AdminClient::CreateTopic(rd_kafka_NewTopic_t* topic, int timeout_ms) {
 
       if (errcode != RD_KAFKA_EVENT_CREATETOPICS_RESULT) {
         if (errmsg) {
-          return Baton(static_cast<RdKafka::ErrorCode>(errcode), std::string(errmsg));
+          return Baton(static_cast<RdKafka::ErrorCode>(errcode), std::string(errmsg)); // NOLINT
         } else {
           return Baton(static_cast<RdKafka::ErrorCode>(errcode));
         }
@@ -384,7 +384,7 @@ Baton AdminClient::CreatePartitions(
 
       if (errcode != RD_KAFKA_EVENT_CREATEPARTITIONS_RESULT) {
         if (errmsg) {
-          return Baton(static_cast<RdKafka::ErrorCode>(errcode), std::string(errmsg));
+          return Baton(static_cast<RdKafka::ErrorCode>(errcode), std::string(errmsg)); // NOLINT
         } else {
           return Baton(static_cast<RdKafka::ErrorCode>(errcode));
         }

--- a/src/admin.cc
+++ b/src/admin.cc
@@ -232,9 +232,14 @@ Baton AdminClient::CreateTopic(rd_kafka_NewTopic_t* topic, int timeout_ms) {
     for (int i = 0 ; i < static_cast<int>(created_topic_count) ; i++) {
       const rd_kafka_topic_result_t *terr = restopics[i];
       const rd_kafka_resp_err_t errcode = rd_kafka_topic_result_error(terr);
+      const char *errmsg = rd_kafka_topic_result_error_string(terr);
 
       if (errcode != RD_KAFKA_EVENT_CREATETOPICS_RESULT) {
-        return Baton(static_cast<RdKafka::ErrorCode>(errcode));
+        if (errmsg) {
+          return Baton(static_cast<RdKafka::ErrorCode>(errcode), std::string(errmsg));
+        } else {
+          return Baton(static_cast<RdKafka::ErrorCode>(errcode));
+        }
       }
     }
 
@@ -375,9 +380,14 @@ Baton AdminClient::CreatePartitions(
     for (int i = 0 ; i < static_cast<int>(created_partitions_topic_count) ; i++) {  // NOLINT
       const rd_kafka_topic_result_t *terr = restopics[i];
       const rd_kafka_resp_err_t errcode = rd_kafka_topic_result_error(terr);
+      const char *errmsg = rd_kafka_topic_result_error_string(terr);
 
       if (errcode != RD_KAFKA_EVENT_CREATEPARTITIONS_RESULT) {
-        return Baton(static_cast<RdKafka::ErrorCode>(errcode));
+        if (errmsg) {
+          return Baton(static_cast<RdKafka::ErrorCode>(errcode), std::string(errmsg));
+        } else {
+          return Baton(static_cast<RdKafka::ErrorCode>(errcode));
+        }
       }
     }
 


### PR DESCRIPTION
On failing to create a Topic or adding partitions, if the broker returns an error message,
this is now passed back into the JS error.

fixes https://github.com/Blizzard/node-rdkafka/issues/538

note : currently `librdkafka` is returning a fixed error message when create partitions fails,
that will being fixed with a separate PR to `librdkafka` see https://github.com/edenhill/librdkafka/issues/2154

Co-authored-by: Edoardo Comar <ecomar@uk.ibm.com>
Co-authored-by: Mickael Maison <mickael.maison@gmail.com>
