### PR TITLE
Added missing librdkafka error codes

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -103,6 +103,26 @@ LibrdKafkaError.codes = {
   ERR__UNSUPPORTED_FEATURE: -165,
   /** Awaiting cache update */
   ERR__WAIT_CACHE: -164,
+  /** Operation interrupted */
+  ERR__INTR: -163,
+  /** Key serialization error */
+  ERR__KEY_SERIALIZATION: -162,
+  /** Value serialization error */
+  ERR__VALUE_SERIALIZATION: -161,
+  /** Key deserialization error */
+  ERR__KEY_DESERIALIZATION: -160,
+  /** Value deserialization error */
+  ERR__VALUE_DESERIALIZATION: -159,
+  /** Partial response */
+  ERR__PARTIAL: -158,
+  /** Modification attempted on read-only object */
+  ERR__READ_ONLY: -157,
+  /** No such entry / item not found */
+  ERR__NOENT: -156,
+  /** Read underflow */
+  ERR__UNDERFLOW: -155,
+  /** Invalid type */
+  ERR__INVALID_TYPE: -154,
   /** End internal error codes */
   ERR__END: -100,
 
@@ -171,7 +191,60 @@ LibrdKafkaError.codes = {
   /** Group authorization failed */
   ERR_GROUP_AUTHORIZATION_FAILED: 30,
   /** Cluster authorization failed */
-  ERR_CLUSTER_AUTHORIZATION_FAILED: 31
+  ERR_CLUSTER_AUTHORIZATION_FAILED: 31,
+  /** Invalid timestamp */
+  ERR_INVALID_TIMESTAMP: 32,
+  /** Unsupported SASL mechanism */
+  ERR_UNSUPPORTED_SASL_MECHANISM: 33,
+  /** Illegal SASL state */
+  ERR_ILLEGAL_SASL_STATE: 34,
+  /** Unuspported version */
+  ERR_UNSUPPORTED_VERSION: 35,
+  /** Topic already exists */
+  ERR_TOPIC_ALREADY_EXISTS: 36,
+  /** Invalid number of partitions */
+  ERR_INVALID_PARTITIONS: 37,
+  /** Invalid replication factor */
+  ERR_INVALID_REPLICATION_FACTOR: 38,
+  /** Invalid replica assignment */
+  ERR_INVALID_REPLICA_ASSIGNMENT: 39,
+  /** Invalid config */
+  ERR_INVALID_CONFIG: 40,
+  /** Not controller for cluster */
+  ERR_NOT_CONTROLLER: 41,
+  /** Invalid request */
+  ERR_INVALID_REQUEST: 42,
+  /** Message format on broker does not support request */
+  ERR_UNSUPPORTED_FOR_MESSAGE_FORMAT: 43,
+  /** Isolation policy volation */
+  ERR_POLICY_VIOLATION: 44,
+  /** Broker received an out of order sequence number */
+  ERR_OUT_OF_ORDER_SEQUENCE_NUMBER: 45,
+  /** Broker received a duplicate sequence number */
+  ERR_DUPLICATE_SEQUENCE_NUMBER: 46,
+  /** Producer attempted an operation with an old epoch */
+  ERR_INVALID_PRODUCER_EPOCH: 47,
+  /** Producer attempted a transactional operation in an invalid state */
+  ERR_INVALID_TXN_STATE: 48,
+  /** Producer attempted to use a producer id which is not
+   *  currently assigned to its transactional id */
+  ERR_INVALID_PRODUCER_ID_MAPPING: 49,
+  /** Transaction timeout is larger than the maximum
+   *  value allowed by the broker's max.transaction.timeout.ms */
+  ERR_INVALID_TRANSACTION_TIMEOUT: 50,
+  /** Producer attempted to update a transaction while another
+   *  concurrent operation on the same transaction was ongoing */
+  ERR_CONCURRENT_TRANSACTIONS: 51,
+  /** Indicates that the transaction coordinator sending a
+   *  WriteTxnMarker is no longer the current coordinator for a
+   *  given producer */
+  ERR_TRANSACTION_COORDINATOR_FENCED: 52,
+  /** Transactional Id authorization failed */
+  ERR_TRANSACTIONAL_ID_AUTHORIZATION_FAILED: 53,
+  /** Security features are disabled */
+  ERR_SECURITY_DISABLED: 54,
+  /** Operation not attempted */
+  ERR_OPERATION_NOT_ATTEMPTED: 55
 };
 
 for (var key in librdkafka.errorCodes) {


### PR DESCRIPTION
While testing the new AdminClient features (very cool btw!) I noticed node-rdkafka was missing the `ERR_TOPIC_ALREADY_EXISTS` error code.

Upon closer inspection, it looks like error codes were not updated when we moved to librdkafka 0.11.5.

To use error codes in JS, we have to use `Kafka.CODES.ERRORS.ERR_TOPIC_ALREADY_EXISTS`. I wonder if we could have a shortcut that drops one of the middle bits `CODES` or `ERRORS`. Still it's better than using the error numbers directly!