### PR TITLE
Update librdkafka to 0.11.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Copyright (c) 2016 Blizzard Entertainment.
 
 The `node-rdkafka` library is a high-performance NodeJS client for [Apache Kafka](http://kafka.apache.org/) that wraps the native  [librdkafka](https://github.com/edenhill/librdkafka) library.  All the complexity of balancing writes across partitions and managing (possibly ever-changing) brokers should be encapsulated in the library.
 
-__This library currently uses `librdkafka` version `0.11.5`.__
+__This library currently uses `librdkafka` version `0.11.6`.__
 
 ## Reference Docs
 
@@ -93,7 +93,7 @@ var Kafka = require('node-rdkafka');
 
 ## Configuration
 
-You can pass many configuration options to `librdkafka`.  A full list can be found in `librdkafka`'s [Configuration.md](https://github.com/edenhill/librdkafka/blob/v0.11.5/CONFIGURATION.md)
+You can pass many configuration options to `librdkafka`.  A full list can be found in `librdkafka`'s [Configuration.md](https://github.com/edenhill/librdkafka/blob/v0.11.6/CONFIGURATION.md)
 
 Configuration keys that have the suffix `_cb` are designated as callbacks. Some
 of these keys are informational and you can choose to opt-in (for example, `dr_cb`). Others are callbacks designed to

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-rdkafka",
   "version": "2.5.1",
   "description": "Node.js bindings for librdkafka",
-  "librdkafka": "0.11.5",
+  "librdkafka": "0.11.6",
   "main": "lib/index.js",
   "scripts": {
     "configure": "node-gyp configure",


### PR DESCRIPTION
Looking through the changes this should be a fairly small update. There is a version 1.0.0 on the horizon; I think it makes sense to produce one last release with this version, as there seem to be quite a lot of changes in 1.0.0.

Note: I'm still in the process of actually testing this version, and we do not have a Windows environment so I just bumped the version in package.json and checked that that nuget package seems to be available.