### PR TITLE
Remove poll interval on disconnect

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -221,9 +221,9 @@ Producer.prototype.setPollInterval = function(interval) {
 
   // Handle disconnections
   this.once('disconnected', function() {
-    // Just rerun this function. It will unset the original
-    // interval and then bind to ready
-    self.setPollInterval(interval);
+    // Just rerun this function with interval 0. If any
+    // poll interval is set, this will remove it
+    self.setPollInterval(0);
   });
 
   return this;


### PR DESCRIPTION
When disconnecting a producer, if an poll interval was set, there was a new call `self.setPollInterval(interval)`.

But on this new call there is a check `if (!this._isConnected)`. If it is not connected, a new listener will be bound on the "ready" event. This can happen because the flag `_isConnected` is also changed on the event "disconnect". Sometimes, the `setPollInterval` "disconnect" listener will be triggered first, and thus a new function will be bound on "ready".

I believe we should instead clear everything on "disconnect" and not risk biding listeners, so in this change I call `self.setPollInterval(0);` which should clear any interval.

Related discussion: https://github.com/Blizzard/node-rdkafka/issues/395