### PR TITLE
Add way to consume messages with a Stream per TopicPartition

### DIFF
--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -511,14 +511,14 @@ KafkaConsumer.prototype._consumeStreams = function() {
           // TODO: move this pausing to the start of a consume call, so the stream has a
           // chance to drain before we pause. Remember: avoid all pausing when possible, 
           // as it clears the fetch queue of librdkafka.
-          this.pause([{ topic: stream.topic, partition: stream.partition }])
+          // this.pause([{ topic: stream.topic, partition: stream.partition }])
 
           stream.once('drain', () => {
             // TODO: make this resilient to the streams having ended / removed from the consumer
             // TODO: somehow only resume this if we had to pause it at the last moment
 
             // resume streams now that we have a stream with space in the buffer again
-            this.resume([{ topic: stream.topic, partition: stream.partition }]);
+            // this.resume([{ topic: stream.topic, partition: stream.partition }]);
           })
         }
 

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -128,6 +128,18 @@ function KafkaConsumer(conf, topicConf) {
   this._consumeTimeout = 1000;
   this._waitInterval = 1000;
   this._streams = [];
+  this.on('disconnected', () => {
+    var finishingStreams = this._streams.map((stream) => {
+      const finishing = new Promise((resolve) => stream.once('finish', resolve))
+      stream.end()
+
+      return finishing
+    })
+
+    Promise.all(finishingStreams).then(() => {
+      this.emit('finished')
+    })
+  })
 }
 
 /**
@@ -570,6 +582,14 @@ KafkaConsumer.prototype.stream = function(toppar) {
   const stream = new TopicPartitionStream(toppar);
 
   this._streams.push(stream);
+
+  const removeStream =  () => {
+    this._streams = this._streams.filter((s) => s !== stream)
+  }
+
+  // remove any streams that have ended (either finished or destroyed)
+  stream.once('finish', removeStream);
+  stream.once('close', removeStream);
 
   if (this._streams.length === 1) {
     // start consumption with streams.

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -481,11 +481,6 @@ KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, cb) {
 
 KafkaConsumer.prototype._consumeStreams = function() {
   if (this.consuming) return;
-
-  // TODO: determine fetch size based on available buffer size streams, perhaps timeout too
-  var fetchSize = 1
-  var timeoutMs = this._consumeTimeout || 1000;
-
   // Track whether already in the middle of consuming for streams, so we can make sure the
   // back-pressure is implemented correctly.
   this.consuming = true;
@@ -494,11 +489,12 @@ KafkaConsumer.prototype._consumeStreams = function() {
     return this._streams.find((s) => s.topic === topic && s.partition === partition);
   };
 
+  const readMore = () => {
+    this.consuming = false;
+    this._consumeStreams();
+  }
+
   const readMoreLater = (delay) => {
-    const readMore = () => {
-      this.consuming = false;
-      this._consumeStreams();
-    }
 
     if (delay) {
       setTimeout(readMore, delay).unref();
@@ -506,6 +502,18 @@ KafkaConsumer.prototype._consumeStreams = function() {
       setImmediate(readMore);
     }
   };
+  
+
+  if (!this.isConnected()) {
+    this.once('ready', readMore)
+    return
+  }
+
+  // TODO: determine fetch size based on available buffer size streams, perhaps timeout too
+  var fetchSize = 1
+  var timeoutMs = this._consumeTimeout || 1000;
+
+
 
   const pushMessages = (messages) => {
     return messages.reduce((resume, message) => {
@@ -552,7 +560,7 @@ KafkaConsumer.prototype._consumeStreams = function() {
       // no messages 
       return readMoreLater(this._waitInterval);
     } else {
-      if (this.pushMessages(messages, false)) {
+      if (pushMessages(messages, false)) {
         // TODO: implement the determining of the fetch size and delay for consuming, given
         // the space in buffers of consuming streams. 
         // Use the difference between how much we wanted to fetch and what we actually did

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -607,7 +607,7 @@ KafkaConsumer.prototype._consumeStreams = function() {
   });
 };
 
-KafkaConsumer.prototype.stream = function(toppar) {
+KafkaConsumer.prototype.stream = function(toppar, streamOptions) {
   var toppar = TopicPartition.create(toppar);
   const existing = this._streams.find(({ topic, partition }) => {
     return topic === toppar.topic && partition === toppar.partition;
@@ -615,7 +615,7 @@ KafkaConsumer.prototype.stream = function(toppar) {
 
   if (existing) return existing
 
-  const stream = new TopicPartitionStream(toppar);
+  const stream = new TopicPartitionStream(toppar, streamOptions);
 
   this._streams.push(stream);
 

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -126,6 +126,7 @@ function KafkaConsumer(conf, topicConf) {
   this.topicConfig = topicConf;
 
   this._consumeTimeout = 1000;
+  this._waitInterval = 1000;
   this._streams = [];
 }
 
@@ -466,6 +467,98 @@ KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, cb) {
 
 };
 
+KafkaConsumer.prototype._consumeStreams = function() {
+  if (this.consuming) return;
+
+  // TODO: determine fetch size based on available buffer size streams, perhaps timeout too
+  var fetchSize = 1
+  var timeoutMs = this._consumeTimeout || 1000;
+
+  // Track whether already in the middle of consuming for streams, so we can make sure the
+  // back-pressure is implemented correctly.
+  this.consuming = true;
+
+  const getStream = ({ topic, partition }) => {
+    return this._streams.find((s) => s.topic === topic && s.partition === partition);
+  };
+
+  const readMoreLater = (delay) => {
+    const readMore = () => {
+      this.consuming = false;
+      this._consumeStreams();
+    }
+
+    if (delay) {
+      setTimeout(readMore, delay).unref();
+    } else {
+      setImmediate(readMore);
+    }
+  };
+
+  const pushMessages = (messages) => {
+    return messages.reduce((resume, message) => {
+      // TODO: make this resilient to the streams having ended / removed from the consumer
+      const stream = getStream(message);
+      if (!stream) {
+        // drop messages for which we no longer have a stream
+        return resume;
+      } else {
+        // Write first, so we don't lose any messages, even if that means overfilling buffers a bit.
+        let written = stream.write(message);
+
+        if (!written) {
+          // pause consumption for this toppar, so we can resume consuming for others
+          // TODO: move this pausing to the start of a consume call, so the stream has a
+          // chance to drain before we pause. Remember: avoid all pausing when possible, 
+          // as it clears the fetch queue of librdkafka.
+          this.pause([{ topic: stream.topic, partition: stream.partition }])
+
+          stream.once('drain', () => {
+            // TODO: make this resilient to the streams having ended / removed from the consumer
+            // TODO: somehow only resume this if we had to pause it at the last moment
+
+            // resume streams now that we have a stream with space in the buffer again
+            this.resume([{ topic: stream.topic, partition: stream.partition }]);
+          })
+        }
+
+        // as long as 1 stream has buffer size left, we can continue
+        return written || resume;
+      }
+    }, false);
+  };
+
+  return this._consumeNum(timeoutMs, fetchSize, (err, messages) => {
+    if (err) {
+      this.emit('error', err);
+      // if this didn't kill it because error got handled, continue?
+    }
+
+    if (messages && !Array.isArray(messages)) messages = [messages]
+
+    if (!messages || messages.length < 1) {
+      // no messages 
+      return readMoreLater(this._waitInterval);
+    } else {
+      if (this.pushMessages(messages, false)) {
+        // TODO: implement the determining of the fetch size and delay for consuming, given
+        // the space in buffers of consuming streams. 
+        // Use the difference between how much we wanted to fetch and what we actually did
+        // as a factor to increase the delay until the next read.
+        // Give priority to making sure we keep reading, even if that means we have to slow 
+        // down, so we can minimise pauses while remaining reactive to things like rebalance
+        // events.
+        let delay = 0;
+        readMoreLater(delay)
+      } else {
+        // All streams are buffered up. Give a bit of extra time to allow them to drain to
+        // try and prevent pausing (and clearing of librdkafka's fetch queue).
+        return readMoreLater(this.waitInterval * 2);
+      }
+    }
+  });
+};
+
 KafkaConsumer.prototype.stream = function(toppar) {
   var toppar = TopicPartition.create(toppar);
   const existing = this._streams.find(({ topic, partition }) => {
@@ -477,6 +570,13 @@ KafkaConsumer.prototype.stream = function(toppar) {
   const stream = new TopicPartitionStream(toppar);
 
   this._streams.push(stream);
+
+  if (this._streams.length === 1) {
+    // start consumption with streams.
+    // TODO: figure out if we couldn't have this triggered by the first
+    // consumption of a stream
+    this._consumeStreams();
+  }
 
   return stream;
 }

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -127,6 +127,7 @@ function KafkaConsumer(conf, topicConf) {
 
   this._consumeTimeout = 1000;
   this._waitInterval = 1000;
+  this._maxFetchSize = 16;
   this._streams = [];
   this._bufferedStreams = [];
   this._pausedStreams = [];
@@ -505,6 +506,20 @@ KafkaConsumer.prototype._consumeStreams = function() {
     return Math.max(0, state.highWaterMark - state.length);
   };
 
+
+  // Determine the fetch size based on the available space in streams. Once space
+  // becomes more limited compared to fetch size, fetch size is reduced to at least
+  // 1 message per fetch, to slow down consumption and prevent pauses.
+  const getFetchSize = (streams, throttleFactor = 3) => {
+    const totalSpaceAvailable = streams.reduce((subTotal, stream) => {
+      return subTotal + getSpaceAvailable(stream);
+    }, 0);
+    const throttledSize = Math.ceil(totalSpaceAvailable / throttleFactor);
+
+    // anywhere between 1 and fetchSize
+    return Math.max(1, Math.min(this._maxFetchSize, throttledSize));
+  };
+
   const readMore = () => {
     this.consuming = false;
     this._consumeStreams();
@@ -557,7 +572,7 @@ KafkaConsumer.prototype._consumeStreams = function() {
   }
 
   // TODO: determine fetch size based on available buffer size streams, perhaps timeout too
-  var fetchSize = 1
+  var fetchSize = getFetchSize(this._streams);
   var timeoutMs = this._consumeTimeout || 1000;
 
   // manage pausing and resuming of streams

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -16,6 +16,7 @@ var Kafka = require('../librdkafka');
 var KafkaConsumerStream = require('./kafka-consumer-stream');
 var LibrdKafkaError = require('./error');
 var TopicPartition = require('./topic-partition');
+var TopicPartitionStream = require('./topic-partition-stream');
 var shallowCopy = require('./util').shallowCopy;
 
 util.inherits(KafkaConsumer, Client);
@@ -125,6 +126,7 @@ function KafkaConsumer(conf, topicConf) {
   this.topicConfig = topicConf;
 
   this._consumeTimeout = 1000;
+  this._streams = [];
 }
 
 /**
@@ -463,6 +465,21 @@ KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, cb) {
   });
 
 };
+
+KafkaConsumer.prototype.stream = function(toppar) {
+  var toppar = TopicPartition.create(toppar);
+  const existing = this._streams.find(({ topic, partition, stream}) => {
+    return topic === toppar.topic && partition === toppar.partition;
+  })
+
+  if (existing) return existing.stream;
+
+  const stream = new TopicPartitionStream(toppar);
+
+  this._streams.push({ topic: toppar.topic, partition: toppar.partition, stream });
+
+  return stream;
+}
 
 /**
  * This callback returns the message read from Kafka.

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -128,6 +128,9 @@ function KafkaConsumer(conf, topicConf) {
   this._consumeTimeout = 1000;
   this._waitInterval = 1000;
   this._streams = [];
+  this._bufferedStreams = [];
+  this._pausedStreams = [];
+
   this.on('disconnected', () => {
     var finishingStreams = this._streams.map((stream) => {
       const finishing = new Promise((resolve) => stream.once('finish', resolve))
@@ -489,20 +492,64 @@ KafkaConsumer.prototype._consumeStreams = function() {
     return this._streams.find((s) => s.topic === topic && s.partition === partition);
   };
 
+  const isStreamPaused = (stream) => {
+    return this._pausedStreams.includes(stream);
+  };
+
+  const isStreamBufferFull = (stream) => {
+    return this._bufferedStreams.includes(stream);
+  }
+
+  const getSpaceAvailable = (stream) => {
+    const state = stream._writableState;
+    return Math.max(0, state.highWaterMark - state.length);
+  };
+
   const readMore = () => {
     this.consuming = false;
     this._consumeStreams();
-  }
+  };
 
   const readMoreLater = (delay) => {
-
     if (delay) {
       setTimeout(readMore, delay).unref();
     } else {
       setImmediate(readMore);
     }
   };
-  
+
+  const pushMessages = (messages) => {
+    messages.forEach((message) => {
+      // TODO: make this resilient to the streams having ended / removed from the consumer
+      const stream = getStream(message);
+      if (!stream) {
+        // drop messages for which we no longer have a stream
+        return;
+      } else {
+        // Write first, so we don't lose any messages, even if that means overfilling buffers a bit.
+        let continueWriting = stream.write(message);
+
+        if (!continueWriting && !isStreamBufferFull(stream)) {
+          // record this stream has having a full buffer
+          this._bufferedStreams.push(stream);
+
+          stream.once('drain', () => {
+            // TODO: make this resilient to the streams having ended / removed from the consumer
+            this._bufferedStreams = this._bufferedStreams.filter((s) => s !== stream);
+          })
+        }
+
+        return
+      }
+    })
+
+    const continueConsumption = this._streams.reduce((resume, stream) => {
+      // as long as a single stream still has space in it's buffers, continue in normal mode
+      return resume || !isStreamBufferFull(stream);
+    }, false);
+
+    return continueConsumption;
+  };
 
   if (!this.isConnected()) {
     this.once('ready', readMore)
@@ -513,40 +560,20 @@ KafkaConsumer.prototype._consumeStreams = function() {
   var fetchSize = 1
   var timeoutMs = this._consumeTimeout || 1000;
 
+  // manage pausing and resuming of streams
+  const toBePaused = this._bufferedStreams
+    .filter((stream) => !this._pausedStreams.includes(stream))
+    .map(({ topic, partition }) => ({ topic, partition }))
+  const toBeResumed = this._pausedStreams
+    .filter((stream) => !this._bufferedStreams.includes(stream))
+    .map(({ topic, partition }) => ({ topic, partition }))
 
+  if (toBePaused.length > 0) this.pause(toBePaused);
+  if (toBeResumed.length > 0) this.resume(toBeResumed);
 
-  const pushMessages = (messages) => {
-    return messages.reduce((resume, message) => {
-      // TODO: make this resilient to the streams having ended / removed from the consumer
-      const stream = getStream(message);
-      if (!stream) {
-        // drop messages for which we no longer have a stream
-        return resume;
-      } else {
-        // Write first, so we don't lose any messages, even if that means overfilling buffers a bit.
-        let written = stream.write(message);
-
-        if (!written) {
-          // pause consumption for this toppar, so we can resume consuming for others
-          // TODO: move this pausing to the start of a consume call, so the stream has a
-          // chance to drain before we pause. Remember: avoid all pausing when possible, 
-          // as it clears the fetch queue of librdkafka.
-          // this.pause([{ topic: stream.topic, partition: stream.partition }])
-
-          stream.once('drain', () => {
-            // TODO: make this resilient to the streams having ended / removed from the consumer
-            // TODO: somehow only resume this if we had to pause it at the last moment
-
-            // resume streams now that we have a stream with space in the buffer again
-            // this.resume([{ topic: stream.topic, partition: stream.partition }]);
-          })
-        }
-
-        // as long as 1 stream has buffer size left, we can continue
-        return written || resume;
-      }
-    }, false);
-  };
+  this._pausedStreams = this._pausedStreams
+    .concat(toBePaused)
+    .filter((stream) => !toBeResumed.includes(stream))
 
   return this._consumeNum(timeoutMs, fetchSize, (err, messages) => {
     if (err) {
@@ -573,7 +600,8 @@ KafkaConsumer.prototype._consumeStreams = function() {
       } else {
         // All streams are buffered up. Give a bit of extra time to allow them to drain to
         // try and prevent pausing (and clearing of librdkafka's fetch queue).
-        return readMoreLater(this.waitInterval * 2);
+        let delay = 0
+        return readMoreLater(delay);
       }
     }
   });

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -602,7 +602,7 @@ KafkaConsumer.prototype._consumeStreams = function() {
       // no messages 
       return readMoreLater(this._waitInterval);
     } else {
-      if (pushMessages(messages, false)) {
+      if (pushMessages(messages)) {
         // TODO: implement the determining of the fetch size and delay for consuming, given
         // the space in buffers of consuming streams. 
         // Use the difference between how much we wanted to fetch and what we actually did
@@ -615,7 +615,7 @@ KafkaConsumer.prototype._consumeStreams = function() {
       } else {
         // All streams are buffered up. Give a bit of extra time to allow them to drain to
         // try and prevent pausing (and clearing of librdkafka's fetch queue).
-        let delay = 0
+        let delay = this._waitInterval;
         return readMoreLater(delay);
       }
     }

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -468,15 +468,15 @@ KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, cb) {
 
 KafkaConsumer.prototype.stream = function(toppar) {
   var toppar = TopicPartition.create(toppar);
-  const existing = this._streams.find(({ topic, partition, stream}) => {
+  const existing = this._streams.find(({ topic, partition }) => {
     return topic === toppar.topic && partition === toppar.partition;
   })
 
-  if (existing) return existing.stream;
+  if (existing) return existing
 
   const stream = new TopicPartitionStream(toppar);
 
-  this._streams.push({ topic: toppar.topic, partition: toppar.partition, stream });
+  this._streams.push(stream);
 
   return stream;
 }

--- a/lib/topic-partition-stream.js
+++ b/lib/topic-partition-stream.js
@@ -5,12 +5,17 @@ var util = require('util');
 
 util.inherits(TopicPartitionStream, Transform);
 
-function TopicPartitionStream(toppar, buffer, options={}) {
+function TopicPartitionStream(toppar, options={}) {
   if (!(this instanceof TopicPartitionStream)) {
     return new TopicPartitionStream(toppar, options);
   } 
 
-  Transform.call(this, { ...options, objectMode: true });
+  Transform.call(this, { 
+    ...options, 
+    objectMode: true, 
+    readableHighWaterMark: 8,
+    writableHighWaterMark: 8
+  });
 
   this.topic = toppar.topic;
   this.partition = toppar.partition;

--- a/lib/topic-partition-stream.js
+++ b/lib/topic-partition-stream.js
@@ -1,0 +1,14 @@
+module.exports = TopicPartitionStream;
+
+var Readable = require('stream').Readable;
+var util = require('util');
+
+util.inherits(TopicPartitionStream, Readable);
+
+function TopicPartitionStream(toppar, options) {
+  if (!(this instanceof TopicPartitionStream)) {
+    return new TopicPartitionStream(toppar, options);
+  }
+
+  Readable.call(this, { ...options, objectMode: true });
+}

--- a/lib/topic-partition-stream.js
+++ b/lib/topic-partition-stream.js
@@ -1,14 +1,22 @@
 module.exports = TopicPartitionStream;
 
-var Readable = require('stream').Readable;
+var Transform = require('stream').Transform;
 var util = require('util');
 
-util.inherits(TopicPartitionStream, Readable);
+util.inherits(TopicPartitionStream, Transform);
 
-function TopicPartitionStream(toppar, options) {
+function TopicPartitionStream(toppar, buffer, options={}) {
   if (!(this instanceof TopicPartitionStream)) {
     return new TopicPartitionStream(toppar, options);
-  }
+  } 
 
-  Readable.call(this, { ...options, objectMode: true });
+  Transform.call(this, { ...options, objectMode: true });
+
+  this.topic = toppar.topic;
+  this.partition = toppar.partition;
+}
+
+
+TopicPartitionStream.prototype._transform = function(message, encoding, callback) {
+  callback(null, message);
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jshint": "^2.9.7",
     "mocha": "^5.2.0",
     "node-gyp": "3.x",
+    "sinon": "^7.2.2",
     "toolkit-jsdoc": "^1.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "bindings": "^1.3.1",
+    "highland": "^2.13.0",
     "nan": "^2.11.1"
   },
   "engines": {

--- a/test/kafka-consumer.spec.js
+++ b/test/kafka-consumer.spec.js
@@ -134,15 +134,18 @@ module.exports = {
         const stream1 = client.stream({ topic: 'test', partition: 0 });
         const stream2 = client.stream({ topic: 'test', partition: 1 });
         const stream3 = client.stream({ topic: 'test', partition: 0 });
+        const stream4 = client.stream({ topic: 'test', partition: 2 }, { highWaterMark: 3 })
         
         t.ok(stream1 instanceof Transform);
         t.equal(stream1.topic, 'test', 'toppar stream has a topic attribute');
         t.equal(stream1.partition, 0, 'toppar stream has a partition attribute');
         t.notEqual(stream1, stream2, 'returns a separate stream for each different toppar');
         t.equal(stream1, stream3, 'returns the same toppar stream for the same toppar');
+        t.equal(stream4._readableState.highWaterMark, 3, 'forward stream options to the toppar stream');
 
-        stream1.destroy()
-        stream2.destroy()
+        stream1.destroy();
+        stream2.destroy();
+        stream4.destroy();
       },
 
 

--- a/test/kafka-consumer.spec.js
+++ b/test/kafka-consumer.spec.js
@@ -8,7 +8,7 @@
  */
 
 var KafkaConsumer = require('../lib/kafka-consumer');
-var Readable = require('stream').Readable;
+var Transform = require('stream').Transform;
 var t = require('assert');
 
 var client;
@@ -50,7 +50,9 @@ module.exports = {
       const stream2 = client.stream({ topic: 'test', partition: 1 });
       const stream3 = client.stream({ topic: 'test', partition: 0 });
       
-      t.ok(stream1 instanceof Readable);
+      t.ok(stream1 instanceof Transform);
+      t.equal(stream1.topic, 'test', 'toppar stream has a topic attribute');
+      t.equal(stream1.partition, 0, 'toppar stream has a partition attribute');
       t.notEqual(stream1, stream2, 'returns a separate stream for each different toppar');
       t.equal(stream1, stream3, 'returns the same toppar stream for the same toppar');
     },

--- a/test/kafka-consumer.spec.js
+++ b/test/kafka-consumer.spec.js
@@ -68,10 +68,12 @@ module.exports = {
         client._isConnecting = false;
         client._isConnected = true;
       },
-      'afterEach': function() {
+      'afterEach': function(done) {
         client.isConnected.returns(false);
         client._isConnecting = false;
-        client._isConnected = false; 
+        client._isConnected = false;
+        client.once('finished', done);
+        client.emit('disconnected');
       },
       'can return a toppar stream': function() {
         const stream1 = client.stream({ topic: 'test', partition: 0 });
@@ -83,6 +85,9 @@ module.exports = {
         t.equal(stream1.partition, 0, 'toppar stream has a partition attribute');
         t.notEqual(stream1, stream2, 'returns a separate stream for each different toppar');
         t.equal(stream1, stream3, 'returns the same toppar stream for the same toppar');
+
+        stream1.destroy()
+        stream2.destroy()
       },
     }
   },

--- a/test/kafka-consumer.spec.js
+++ b/test/kafka-consumer.spec.js
@@ -8,6 +8,7 @@
  */
 
 var KafkaConsumer = require('../lib/kafka-consumer');
+var Readable = require('stream').Readable;
 var t = require('assert');
 
 var client;
@@ -43,6 +44,15 @@ module.exports = {
       t.deepStrictEqual(topicConfig, {});
       t.deepStrictEqual(client.topicConfig, {});
       t.notEqual(topicConfig, client.topicConfig);
+    },
+    'can return a toppar stream': function() {
+      const stream1 = client.stream({ topic: 'test', partition: 0 });
+      const stream2 = client.stream({ topic: 'test', partition: 1 });
+      const stream3 = client.stream({ topic: 'test', partition: 0 });
+      
+      t.ok(stream1 instanceof Readable);
+      t.notEqual(stream1, stream2, 'returns a separate stream for each different toppar');
+      t.equal(stream1, stream3, 'returns the same toppar stream for the same toppar');
     },
   },
 };


### PR DESCRIPTION
I'd like to propose an alternative approach to consuming messages through a stream, which should not only solve a bunch of outstanding issues, but also increase throughput and performance in certain cases. The approach differs in two significant ways:

- **A separate stream is created for each topic-partition** the consumer is either subscribed to or had manually assigned.
- **A stream is created from an instantiated consumer**, for now proposed as `ReadableStream : consumer.stream(toppar, options)` (but could include returning _all_ streams or a subset of streams).

## Stream per TopicPartition

The current implementation of the _KafkaConsumerStream_ implements a single stream for all the messages that it's consumer might consume. While simple and straightforward, the main issue with becomes apparent when one consumes these messages to do further stream processing with. 

In Kafka, the partition, or more accurately the topic-partition, is the unit of concurrency. Within it the ordering of messages is guaranteed, which makes it an invaluable building block for using the immutable log provided in stream processing. The _ConsumerGroups_, with cluster wide orchestration of which consumer are processing which partitions,  further showcase how partitions are meant to work individually.

When all messages from all topic-partitions come through a single stream, the necessarily have to share back-pressure with each other. Even when splitting it down stream, all partitions share a single buffer. This means that if processing of 1 partition takes a long time, processing for _all_ other partitions have to wait, too. If something goes wrong in this, _all_ partitions have to be stopped. When _ConsumerGroup_ assigns new partitions, _all_ partitions have to be stopped, wait to finished (or canceled) and reconstructed, even if only 1 partition was removed or added.

Instead, when each partition has it's own stream, all of these things can happen individually. If processing from 1 topic is a lot faster than from another one, but they do share the same consumer group (totally reasonable and common!), each partition can be processed at it's own pace.

This approach has a couple of additional benefits, mostly due to the way it allows the message consumption to be implemented (see below for details):

- Rebalance events for consumer groups are only delivered when consuming messages. They _need_ to be reacted to in order for a consumer not to lose it's assigned partitions. A single slowly processed partition can prevent any more consumption to happen. 
- Commit confirmations are delivered as part of consuming messages. But what if you don't want to process (read: consume) the next message until you've confirmed that committing the current one was successful? Unless you get fancy with custom pausing and resuming of partitions so you can call _consumer.consume_ without actually reading any more messages, massively hurting performance, you're in a deadlock! If some other stream causes another read, that won't be an issue.

## Creating streams using `consumer.stream(toppar)`

As highlighted above, using a _ConsumerGroup_, partitions might be re-assigned between various consumers at any time. While the consumer might be long-lived, this might not be true for a stream at all. To stop consuming or processing messages, a Stream should reach it's end, so Node's built-in clean up facilities can be effective. Something has to own and manage these streams across the lifetime of the consumer, making this API a better fit.

While that is one reason for this API ,implementing a stream processing framework, we constantly find that we're referencing _stream.consumer_ in order to perform other operations, like pausing, resuming, seeking, etc. The stream can be a way to consume messages of a consumer, just like consumption per 1 message or through a loop using `consumer.consume()`. That way, it's purely describing the mechanism for _consuming_ messages and doesn't need anything else.

## Implementation thus far and other benefits

In the last couple of months, in a project where we're processing several gigabytes of location events each day, we've implemented our own custom _KafkaConsumerStream_, trying to address some of the issues listed above. While it still used a single stream for all topic partitions, we did uncover some constraints on how to make consumption at _any_ rate performant:

- You want to call `consumer.consume` regularly, as to deliver all the required events and stay known as a healthy worker (not consuming is the metric for determining a node to be unhealthy and in need of termination).
- You can use `consumer.pause` and `consumer.resume` to control for which toppars you want to consume messages by calling `consumer.consume`, while staying assigned to them. This allows processing times for messages that exceed the rebalance response window, delivery reports to be delivered, etc.
- You want to avoid calling `consumer.pause` as it purges the fetch queue `librdkafka` keeps for the toppar in the background. In default configuration, `librdkafka` fetches 100,000 messages per topic partition as quick as it can, ready to be consumed by your application. This creates a buffer that allows for very high throughputs. However, as soon as _pause_ that toppar, the queue is emptied, even if resumed very quickly after. You only want to pause when you're expecting to not read messages for that toppar for a while.

With those constraints in mind, I've taken what I've learned and implemented a proof of concept, with some tests to show that it works. Thus far, the approach generally works as follows:

- The consumer holds a list of all known streams, with a single one for each known topic-partition. 
- A `TopicPartitioionStream` is returned by `consumer.stream(toppar)`, implemented as a [TransformStream](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_implementing_a_transform_stream) (which is made for streams that can both be written to and read from, where input is logically related to the output).
- As soon as a single stream has been returned the consumer starts consuming messages continuously as soon as the consumer is ready.
- It writes the messages as received to the streams as per their topic and partition. Any stream that indicates to have a full buffer is listed as such.
- At the next read (either after a delay, or not if all buffers streams have room in their buffers) the toppars for streams that are full are paused. Any that have since drained are resumed if they were paused earlier.
- Even if all toppars have been paused, consumption continues with at an interval, making sure we remain alive and receive all necessary events.

--- 

There's a bunch more that would need to happen before this could be merged. 

Most notably, I want to bring over the "throttling" mechanism we developed for the single stream, where we try to adapt our consumption rate (read: waits between `consumer.consume`) calls to match the rate at which they are being read of the stream, to further prevent any pausing of toppars. In our own implementation we used both fetch size + delay, but I haven't figured out yet how to do that for multiple streams, where some toppars could go a lot faster than others.

However, before I put more time into that, I'd like to know whether others agree with the approach and it has a chance of getting merged at all. Please feel free to ask any questions, make comments, etc! 

PS: Please keep in mind that I've tried to get this going as a proof of concept as quick as possible and am aware that the coding style doesn't totally fit in with the rest of the project (mostly in terms of ES2015 / ES2016 features). I'm happy to address all of that, but was hoping to discuss on a more conceptual level first!