### PR TITLE
Issue-553: Fixes delivery report performance issue

### DIFF
--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -13,6 +13,7 @@
 #include <nan.h>
 
 #include <vector>
+#include <deque>
 
 #include "rdkafkacpp.h"
 #include "src/common.h"
@@ -129,10 +130,10 @@ class DeliveryReportDispatcher : public Dispatcher {
   DeliveryReportDispatcher();
   ~DeliveryReportDispatcher();
   void Flush();
-  void Add(const DeliveryReport &);
+  size_t Add(const DeliveryReport &);
   void AddCallback(v8::Local<v8::Function>);
  protected:
-  std::vector<DeliveryReport> events;
+  std::deque<DeliveryReport> events;
 };
 
 class Delivery : public RdKafka::DeliveryReportCb {

--- a/src/config.cc
+++ b/src/config.cc
@@ -54,8 +54,24 @@ Conf * Conf::create(RdKafka::Conf::ConfType type, v8::Local<v8::Object> object, 
     }
 
     if (!value->IsFunction()) {
+#if NODE_MAJOR_VERSION > 6
+      if (value->IsInt32()) {
+        string_value = std::to_string(
+          value->Int32Value(Nan::GetCurrentContext()).ToChecked());
+      } else if (value->IsUint32()) {
+        string_value = std::to_string(
+          value->Uint32Value(Nan::GetCurrentContext()).ToChecked());
+      } else if (value->IsBoolean()) {
+        string_value = value->BooleanValue(
+          Nan::GetCurrentContext()).ToChecked() ? "true" : "false";
+      } else {
+        Nan::Utf8String utf8_value(value.As<v8::String>());
+        string_value = std::string(*utf8_value);
+      }
+#else
       Nan::Utf8String utf8_value(value.As<v8::String>());
       string_value = std::string(*utf8_value);
+#endif
       if (rdconf->set(string_key, string_value, errstr)
         != Conf::CONF_OK) {
           delete rdconf;

--- a/util/test-producer-delivery.js
+++ b/util/test-producer-delivery.js
@@ -1,0 +1,100 @@
+const Kafka = require("../lib/index.js");
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const sendData = async (producer, totalMessages) => {
+    const topic = "node";
+    const msg = "dkfljaskldfajkldsjfklasdjfalk;dsjfkl;asjfdskl;fjda;lkfjsdklfsajlkfjdsklfajsklfjsklanklsalkjkljkasfak";
+    const buffer = Buffer.from(msg);
+    const key = "test";
+    for (let n = 0; n < totalMessages; ++n) {
+        let bufferIsFull = false;
+        do {
+            bufferIsFull = false;
+            try {
+                producer.produce(topic, -1, buffer, key, null, n);
+            }
+            catch (error) {
+                // Based on config, and messages, this will execute once
+                if (error.code === Kafka.CODES.ERRORS.ERR__QUEUE_FULL) {
+                    producer.poll();
+                    // The wait introduces 11-12 seconds of latency when dr_cb is true
+                    const start = process.hrtime();
+                    await wait(50);
+                    const latency = process.hrtime(start);
+                    console.info(`Wait took ${latency[0]} seconds`);
+                    bufferIsFull = true;
+                } else {
+                    throw error;
+                }
+            }
+        } while (bufferIsFull);
+    }
+    console.log("Finished producing");
+};
+
+const verifyReports = async (reports, reportsComplete, totalMessages) => {
+    const reportsTimeout = new Promise((resolve, reject) => {
+        setTimeout(() => {
+            reject("Delivery report timed out");
+        }, 10000);
+    });
+    await Promise.race([reportsComplete, reportsTimeout]);
+    await wait(500); // wait for some more delivery reports.
+    if (reports.length === totalMessages) {
+        console.log("Reports count match");
+    } else { 
+        console.error("Reports count doesn't match");
+        return;
+    }
+    for(let n = 0; n < totalMessages; ++n) {
+        if(reports[n].opaque !== n) {
+            console.error("Expect message number does not match");
+        }
+    }
+};
+
+const run = async () => {
+    const reports = [];
+    const totalMessages = 1000100;
+    const producer = new Kafka.Producer({
+        "batch.num.messages": 50000,
+        "compression.codec": "lz4",
+        "delivery.report.only.error": false,
+        "dr_cb": true,
+        "metadata.broker.list": "localhost:9092",
+        "message.send.max.retries": 10000000,
+        "queue.buffering.max.kbytes": 2000000,
+        "queue.buffering.max.messages": 1000000,
+        "queue.buffering.max.ms": 0,
+        "socket.keepalive.enable": true,
+    }, {});
+
+    producer.setPollInterval(100);
+    producer.on("event.log", (obj) => console.log(obj));
+    const reportsComplete = new Promise((resolve) => {
+        producer.on("delivery-report", (err, report) => {
+            reports.push(report);
+            if(reports.length === totalMessages) {
+                resolve();
+            }
+        });
+    });
+
+    const readyPromise = new Promise((resolve) => {
+        producer.on("ready", async () => {
+            console.log("Producer is ready");
+            resolve();
+        });
+        producer.connect();
+    });
+    await readyPromise;
+
+    await sendData(producer, totalMessages);
+    await verifyReports(reports, reportsComplete, totalMessages);
+    process.exit(0);
+};
+
+run().catch((err) => {
+    console.error(err);
+});


### PR DESCRIPTION
Fixes issue 553 by batching delivery report in up to 100 deliveries per `DeliveryReportDispatcher::Flush()`. Each `DeliveryReportDispatcher::Flush()` now takes a maximum of about 500 microseconds with an empty callback in a 3GHz core. If there are remaining delivery reports, then Flush() will request a further callback. Test is included in util/test-producer-delivery.js

- Avoid a copy construction of the DeliveryReport in the for loop by using const-references. This, in turn, avoid dynamically allocating the two strings per delivery report. 
- Delivery only requests a callback when the outstanding delivery reports is 1. There is no need to keep requesting the callback if it has already been requested.
- Fixes an issue I encountered where the debug build of node-rdkafka was throwing an exception during configuration in node8, node10, and node11. I could not start the library at all with a debug build. This is a separate commit because it addresses a different issue.

Please let me know of any concerns.

**Tests**
Test verifies that all delivery reports are delivered and in the correct order.
Tested in Linux Node 8 and Mac Node 10. 

Test result before change
```
myhost:node-rdkafka rusty0412$ time node util/test-producer-delivery.js
Producer is ready
Wait took 8 seconds
Finished producing
Reports count match

real	0m12.206s
user	0m13.689s
sys	0m0.904s
```
Test result after change
```
myhost:node-rdkafka rusty0412$ time node util/test-producer-delivery.js
Producer is ready
Wait took 0 seconds
Finished producing
Reports count match

real	0m10.095s
user	0m11.027s
sys	0m0.901s
```