### PR TITLE
`offset.commit` event documentation and implementation do not match

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ var consumer = new Kafka.KafkaConsumer({
 })
 ```
 
-`this` is bound to the `KafkaConsumer` you have created. By specifying an `offset_commit_cb` you can also listen to the `offset.commit` event as an emitted event. It also has an error parameter and a list of topic partitions. This is not emitted unless opted in.
+`this` is bound to the `KafkaConsumer` you have created. By specifying an `offset_commit_cb` you can also listen to the `offset.commit` event as an emitted event. It receives the list of topic partitions as argument. This is not emitted unless opted in.
 
 ### Message Structure
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,10 @@ export class Client extends NodeJS.EventEmitter {
     on(event: 'event.throttle', listener: (eventData: any) => void): this;
     // delivery
     on(event: 'delivery-report', listener: (error: Error, report: any) => void): this;
+
+    // offsets
+    on(event: 'offset.commit', listener: (topicPartitions: any[]) => void): this;
+
 // ONCE
     // domain events
     once(event: 'data', listener: (arg: ConsumerStreamMessage) => void): this;
@@ -63,6 +67,9 @@ export class Client extends NodeJS.EventEmitter {
 
     // delivery
     once(event: 'delivery-report', listener: (error: Error, report: any) => void): this;
+
+    // offsets
+    once(event: 'offset.commit', listener: (topicPartitions: any[]) => void): this;
 }
 
 export type ErrorWrap<T> = boolean | T;


### PR DESCRIPTION
The _event_ only receives the topic partitions, although it will also get called when an error has occurred (see https://github.com/Blizzard/node-rdkafka/blob/56c31c4e81f2a042666160338ad65dc4f8f2d87e/lib/kafka-consumer.js#L93-L104). This PR goes to assume that the implementation is correct and the documentation is wrong, and then fixes the documentation. I guess another way of looking at the same problem is to say the documentation was correct, but the implementation isn't right now, and should be fixed to produce the two arguments (similar to the way the rebalancing is handled). That would introduce a backwards-incompatible change. Let me know if that makes more sense, and I can update this PR accordingly.

While there: the event is missing in `index.d.ts`. That change depends on the above decision though.