### PR TITLE
Correct type definition for AdminClient.create

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -252,5 +252,5 @@ declare interface InternalAdminClient {
 }
 
 export class AdminClient {
-    create(conf: object): InternalAdminClient;
+    static create(conf: object): InternalAdminClient;
 }


### PR DESCRIPTION
The `static` modifier was missing so typescript was throwing a not found error when trying to use it as a factory method.

```
AdminClient.create()
```