### PR TITLE
Add type declarations for HighLevelProducer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -132,6 +132,16 @@ export class Producer extends Client {
 
 }
 
+export class HighLevelProducer extends Producer {
+  createSerializer(serializer: Function): ({
+    apply: Function | Error;
+    async: boolean
+  });
+
+  setKeySerializer(serializer: Function): void;
+  setValueSerializer(serializer: Function): void;
+}
+
 export const CODES: {
     ERRORS: {
         ERR_BROKER_NOT_AVAILABLE: number;


### PR DESCRIPTION
Adds TypeScript type declarations for the newly added `HighLevelProducer` which were missing.