### PR TITLE
Update for Windows

### DIFF
--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -272,7 +272,7 @@ void DeliveryReportDispatcher::Flush() {
   {
     scoped_mutex_lock lock(async_lock);
     outstanding_event_count = events.size();
-    const size_t flush_count = std::min(outstanding_event_count, 100UL);
+    const size_t flush_count = std::min<size_t>(outstanding_event_count, 100UL);
     events_list.reserve(flush_count);
     for (size_t i = 0; i < flush_count; i++) {
       events_list.emplace_back(std::move(events.front()));


### PR DESCRIPTION
On Windows 10 with windows-build-tools I receive
```
..\src\callbacks.cc(275): error C2589: '(': illegal token on right side of '::' [C:\www\htdocs\cust\wt\kafka\apps\packages\node-rdkafka\build\node-librdkafka.vcxproj]
..\src\callbacks.cc(275): error C2059: syntax error: '::' [C:\www\htdocs\cust\wt\kafka\apps\packages\node-rdkafka\build\node-librdkafka.vcxproj]
```
This appears to be due to macros elsewhere redefining `min`. Making the type explicit solves the problem and compiles just fine.