### PR TITLE
Emit also the error code in the offset.commit event

### DIFF
--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -327,7 +327,8 @@ describe('Consumer/Producer', function() {
         lastOffset = message.offset;
 
         // disconnect in offset commit callback
-        consumer.on('offset.commit', function(offsets) {
+        consumer.on('offset.commit', function(err, offsets) {
+          t.ifError(err);
           t.equal(typeof offsets, 'object', 'offsets should be returned');
 
           consumer.disconnect(function() {

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -93,12 +93,12 @@ function KafkaConsumer(conf, topicConf) {
   if (onOffsetCommit && typeof onOffsetCommit === 'boolean') {
     conf.offset_commit_cb = function(err, offsets) {
       // Emit the event
-      self.emit('offset.commit', offsets);
+      self.emit('offset.commit', err, offsets);
     };
   } else if (onOffsetCommit && typeof onOffsetCommit === 'function') {
     conf.offset_commit_cb = function(err, offsets) {
       // Emit the event
-      self.emit('offset.commit', offsets);
+      self.emit('offset.commit', err, offsets);
       onOffsetCommit.call(self, err, offsets);
     };
   }


### PR DESCRIPTION
Without the err information, the emit event is completely useless as one does not know whether it succeeded or failed, and had to use the callback function.

This is a breaking API change, but follows the convention `(err,data)` used for other events.

Co-authored-by: Edoardo Comar <ecomar@uk.ibm.com>
Co-authored-by: Mickael Maison <mickael.maison@gmail.com>


