### PR TITLE
Fix Windows build for librdkafka 1.0.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Windows build **is not** compiled from `librdkafka` source but it is rather link
 
 Requirements:
  * [node-gyp for Windows](https://github.com/nodejs/node-gyp#on-windows)  (the easies way to get it: `npm --vs2015 install --global --production windows-build-tools`)
- * [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
 
 **Note:** I _still_ do not recommend using `node-rdkafka` in production on Windows. This feature was in high demand and is provided to help develop, but we do not test against Windows, and windows support may lag behind Linux/Mac support because those platforms are the ones used to develop this library. Contributors are welcome if any Windows issues are found :)
 

--- a/deps/windows-install.py
+++ b/deps/windows-install.py
@@ -54,6 +54,9 @@ shutil.copy2(dllPath + '/zlib.dll', buildReleaseDir)
 shutil.copy2(dllPath + '/msvcr120.dll', buildReleaseDir)
 shutil.copy2(dllPath + '/librdkafka.dll', buildReleaseDir)
 shutil.copy2(dllPath + '/librdkafkacpp.dll', buildReleaseDir)
+if not librdkafkaVersion.startswith('0.'):
+    shutil.copy2(dllPath + '/libzstd.dll', buildReleaseDir)
+    shutil.copy2(dllPath + '/msvcp120.dll', buildReleaseDir)
 
 # clean up
 os.remove(outputFile)


### PR DESCRIPTION
The latest _librdkafka_ `1.0.0` has additional dependency `libzstd.dll` that must be included with the Windows build. Thanks to @edenhill it also includes `msvcp120.dll` out of the box so installing VS Build Tools 2013 is no more the requirement (refs #493 and librdkafka [#2103](https://github.com/edenhill/librdkafka/issues/2103)).
This PR assumes that #585 will be merged first.
Also ref #579.