### PR TITLE
Enhance the travis-ci script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,20 @@ language: node_js
 cache:
   directories:
   - node_modules
-node_js:
-  - "4"
-  - "6"
-  - "8"
-  - "10"
+# node_js:
+#   - "4"
+#   - "6"
+#   - "8"
+#   - "10"
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then ./run_docker.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./win_install.bat; fi
 install:
-  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then npm install; fi
+  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" || "$TRAVIS_BUILD_STAGE_NAME" == "Test_on_mac" || "$TRAVIS_BUILD_STAGE_NAME" == "Test_on_win" ]]; then npm install; fi
 
 script:
-  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then make lint;make test;make check; fi
+  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" || "$TRAVIS_BUILD_STAGE_NAME" == "Test_on_mac" || "$TRAVIS_BUILD_STAGE_NAME" == "Test_on_win"  ]]; then make lint;make test;make check; else echo $TRAVIS_BUILD_STAGE_NAME; fi
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,42 +3,51 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
-    node_js:
-      - "4"
-      - "6"
-    services:
-    - docker
-    before_install:
-    - "./run_docker.sh"
-    script:
+  - os: osx
+    osx_image: xcode10
+    env:
+    - CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
+
+  - os: windows
+
+services:
+  - docker
+language: node_js
+node_js:
+  - "4"
+  - "5"
+  - "6"
+  - "7"
+  - "8"
+  - "9"
+  - "10"
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./run_docker.sh          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./win_install.bat; fi
+script:
     - make lint
     - make test
-    - make e2e
-  - os: linux
-    dist: trusty
-    sudo: required
-    node_js: "8"
-    before_deploy:
-    - openssl aes-256-cbc -K $encrypted_a2e08d5c220e_key -iv $encrypted_a2e08d5c220e_iv
-      -in deploy.enc -out /tmp/deploy -d
-    - eval "$(ssh-agent -s)"
-    - chmod 600 /tmp/deploy
-    - ssh-add /tmp/deploy
-    services:
-    - docker
-    before_install:
-    - "./run_docker.sh"
-    script:
-    - make lint
-    - make test
-    - make e2e
-    deploy:
-    - provider: script
-      script: "./make_docs.sh"
+    - make check
+cache:
+  directories:
+  - node_modules
+
+jobs:
+  include:
+    - stage: create_doc
+      provider: script
+      script: 
+        - openssl aes-256-cbc -K $encrypted_a2e08d5c220e_key -iv $encrypted_a2e08d5c220e_iv -in deploy.enc -out /tmp/deploy -d
+        - eval "$(ssh-agent -s)"
+        - chmod 600 /tmp/deploy
+        - ssh-add /tmp/deploy
+        - "./make_docs.sh"
       on:
         branch: master
         tags: true
-    - provider: npm
+    - stage: publish_npm
+      provider: npm
       skip_cleanup: false
       email: webmakersteve@gmail.com
       api_key:
@@ -46,38 +55,3 @@ matrix:
       on:
         branch: master
         tags: true
-  - os: osx
-    osx_image: xcode10
-    env:
-    - CPPFLAGS=-I/usr/local/opt/openssl/include
-    - LDFLAGS=-L/usr/local/opt/openssl/lib
-    before_install:
-    - brew install openssl
-    node_js:
-    - "4"
-    - "6"
-    script:
-    - make lint
-    - make test
-    - make check
-  - os: windows
-    env:
-    - PYTHONHTTPSVERIFY=0
-    before_install:
-#    - choco install python2
-#    - set PATH=C:\Python27;%PATH%
-#    - pip install --upgrade certifi
-    - choco install openssl.light
-    - npm install --global --production windows-build-tools@3.1.0
-    - choco install make
-
-    node_js:
-      - "6"
-    script:
-    - make lint
-    - make test
-    - make check
-language: node_js
-cache:
-  directories:
-  - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,11 +64,12 @@ matrix:
     env:
     - PYTHONHTTPSVERIFY=0
     before_install:
-    - choco install python2
+#    - choco install python2
 #    - set PATH=C:\Python27;%PATH%
 #    - pip install --upgrade certifi
     - choco install openssl.light
     - npm install --global --production windows-build-tools@3.1.0
+    - choco install make
 
     node_js:
       - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,21 @@ matrix:
     - make lint
     - make test
     - make check
+  - os: windows
+    before_install:
+    - choco install openssl.light
+    nodejs
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    script:
+    - make lint
+    - make test
+    - make check
 language: node_js
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,17 @@
 language: node_js
-
+matrix:
+  include:
+    - name: "build on linux"
+      os: linux
+      dist: trusty
+      sudo: required
+      services: docker
+    - name: "build on mac"
+      os: osx
+      osx_image: xcode10
+      env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
+    - name: "build on windows"
+      os: windows
 cache:
   directories:
   - node_modules
@@ -14,20 +26,7 @@ install:
 jobs:
   include:
     - stage: test
-      matrix:
-        include:
-          - name: "build on linux"
-            os: linux
-            dist: trusty
-            sudo: required
-            services: docker
-          - name: "build on mac"
-            os: osx
-            osx_image: xcode10
-            env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
-          - name: "build on windows"
-            os: windows
-      
+      name: "test"
       before_install:
         - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then ./run_docker.sh; fi
         - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,10 +61,12 @@ matrix:
     - make test
     - make check
   - os: windows
+    env:
+    - PYTHONHTTPSVERIFY=0
     before_install:
     - choco install python2
-    - set PATH=C:\Python27;%PATH%
-    - pip install --upgrade certifi
+#    - set PATH=C:\Python27;%PATH%
+#    - pip install --upgrade certifi
     - choco install openssl.light
     - npm install --global --production windows-build-tools@3.1.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,8 @@ matrix:
     before_install:
     - choco install openssl.light
     - npm install --global --production windows-build-tools@3.1.0
+    - wget https://bootstrap.pypa.io/get-pip.py
+    - python get-pip.py
     - pip install --upgrade certifi
     node_js:
       - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: node_js
-matrix:
-  include:
-    - name: "build on linux"
-      os: linux
-      dist: trusty
-      sudo: required
-      services: docker
-    - name: "build on mac"
-      os: osx
-      osx_image: xcode10
-      env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
-    - name: "build on windows"
-      os: windows
+# matrix:
+#   include:
+#     - name: "build on linux"
+#       os: linux
+#       dist: trusty
+#       sudo: required
+#       services: docker
+#     - name: "build on mac"
+#       os: osx
+#       osx_image: xcode10
+#       env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
+#     - name: "build on windows"
+#       os: windows
 cache:
   directories:
   - node_modules
@@ -32,6 +32,32 @@ script:
 
 jobs:
   include:
+    - stage: test
+      os: linux
+      dist: trusty
+      sudo: required
+      services: docker
+      node_js:
+        - "4"
+        - "6"
+        - "8"
+        - "10"
+    - stage: test_on_mac
+      os: osx
+      osx_image: xcode10
+      env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
+      node_js:
+        - "4"
+        - "6"
+        - "8"
+        - "10"
+    - stage: test_on_win
+      os: windows
+      node_js:
+        - "4"
+        - "6"
+        - "8"
+        - "10"
     - stage: create_doc
       provider: script
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,5 @@
 language: node_js
-# matrix:
-#   include:
-#     - name: "build on linux"
-#       os: linux
-#       dist: trusty
-#       sudo: required
-#       services: docker
-#     - name: "build on mac"
-#       os: osx
-#       osx_image: xcode10
-#       env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
-#     - name: "build on windows"
-#       os: windows
+
 cache:
   directories:
   - node_modules
@@ -34,13 +22,6 @@ script:
 
 jobs:
   include:
-    # - stage: test
-    #   os: linux
-    #   dist: trusty
-    #   sudo: required
-    #   services: docker
-    #   node_js:
-    #     - "6"
     - stage: test_on_mac
       os: osx
       osx_image: xcode10

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,7 @@ matrix:
     before_install:
     - choco install openssl.light
     - npm install --global --production windows-build-tools@3.1.0
-    - wget https://bootstrap.pypa.io/get-pip.py
-    - python get-pip.py
+    - choco install pip
     - pip install --upgrade certifi
     node_js:
       - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,4 @@
-matrix:
-  include:
-    - name: "build on linux"
-      os: linux
-      dist: trusty
-      sudo: required
-      services: docker
-    - name: "build on mac"
-      os: osx
-      osx_image: xcode10
-      env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
-    - name: "build on windows"
-      os: windows
-
 language: node_js
-node_js:
-  - "4"
-  - "6"
-  - "8"
-  - "10"
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then ./run_docker.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./win_install.bat; fi
 
 cache:
   directories:
@@ -30,6 +7,28 @@ cache:
 jobs:
   include:
     - stage: test
+      matrix:
+        include:
+          - name: "build on linux"
+            os: linux
+            dist: trusty
+            sudo: required
+            services: docker
+          - name: "build on mac"
+            os: osx
+            osx_image: xcode10
+            env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
+          - name: "build on windows"
+            os: windows
+      node_js:
+        - "4"
+        - "6"
+        - "8"
+        - "10"
+      before_install:
+        - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then ./run_docker.sh; fi
+        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi
+        - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./win_install.bat; fi
       script:
         - make lint
         - make test
@@ -43,15 +42,12 @@ jobs:
         - ssh-add /tmp/deploy
       script:
         - "./make_docs.sh"
-      on:
-        branch: master
-        tags: true
+      if: (tag =~ ^v) AND (branch = master)
     - stage: publish_npm
       provider: npm
       skip_cleanup: false
       email: webmakersteve@gmail.com
       api_key:
         secure: dCHdwKmSLmVU51eAiH/n7OT1WzyD2DZccjVt8luu6w7U61K3dnl26ZNcNqrRjglkCWj2mHwysYrlImNu/7DKoqNn6fJea6EFjESH9EjAgTbIFEbFyl1Bu+u9w68LEk8WKmCLQ4ckdXp4wm5A0G5+tn29Jg3+VBCy9OdZTFEw5Otwp5f/ARqv4vcnOQNNzdhpZX1o6M2i2zyzcjsKyrjUhuJIdtyXbc1H8aMXT4exRcTSTknbbV2pD4YN2mz5XOlORDLTap8q3W7UG5cPPvyd4Wsn6iiXcSlDJ5DZkQkx5DqJdzxE94pkS1WjDodW0TQtA55jj7qVhqwDwiQLHdClxQM4VN7wRDLoMsy811E9ockMwhgHXRjnQSlpRMux/ueqJnYzG7/zpKYokfJc2HoUv5Wx1Ae5nF//viUlYhEWI4E7cJatrnJnulmfJZOwQReOoInwNy7uVuzTVi0K9Q5X73e27nx5sp+gCcG3HiGQ07TB0hyqV0HWioKcYOqBUHnvMHkdMskPWC5mhTpiXcwk6JVdaUqqcwtqks1+9LiboOEYVb6CFIkmOAh/+mbOTDymTYbcKcdDJYFDOVJ8cMiCqIZ3J4gd/5+zTf2wTowYkBI/7t7Jq9X52tlRDmUn6vr6Zs4Ph+7qhpXHc3ov3p3g55s+ug968vDxogAxJt1NCUU=
-      on:
-        branch: master
-        tags: true
+      if: (tag =~ ^v) AND (branch = master)
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ matrix:
   - os: windows
     before_install:
     - choco install python2
+    - refreshenv
     - pip install --upgrade certifi
     - choco install openssl.light
     - npm install --global --production windows-build-tools@3.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ matrix:
     before_install:
     - choco install openssl.light
     - npm install --global --production windows-build-tools@3.1.0
+    - choco install python
     - choco install pip
     - pip install --upgrade certifi
     node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ matrix:
     before_install:
     - choco install openssl.light
     - npm install --global --production windows-build-tools@3.1.0
+    - pip install --upgrade certifi
     node_js:
       - "6"
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
   - os: windows
     before_install:
     - choco install python2
-    - refreshenv
+    - set PATH=C:\Python27;%PATH%
     - pip install --upgrade certifi
     - choco install openssl.light
     - npm install --global --production windows-build-tools@3.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,11 @@ matrix:
         tags: true
   - os: osx
     osx_image: xcode10
+    env:
+    - CPPFLAGS=-I/usr/local/opt/openssl/include
+    - LDFLAGS=-L/usr/local/opt/openssl/lib
+    before_install:
+    - brew install openssl
     nodejs:
     - 4
     - 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,48 +15,41 @@ language: node_js
 cache:
   directories:
   - node_modules
-# node_js:
-#   - "4"
-#   - "6"
-#   - "8"
-#   - "10"
+node_js:
+  - "4"
+  - "6"
+  - "8"
+  - "10"
+sudo: required
+services: docker
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then ./run_docker.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" =~ Test.* ]]; then ./run_docker.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./win_install.bat; fi
 install:
-  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" || "$TRAVIS_BUILD_STAGE_NAME" == "Test_on_mac" || "$TRAVIS_BUILD_STAGE_NAME" == "Test_on_win" ]]; then npm install; fi
+  - if [[ "$TRAVIS_BUILD_STAGE_NAME" =~ Test.* ]]; then npm install; fi
 
 script:
-  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" || "$TRAVIS_BUILD_STAGE_NAME" == "Test_on_mac" || "$TRAVIS_BUILD_STAGE_NAME" == "Test_on_win"  ]]; then make lint;make test;make check; else echo $TRAVIS_BUILD_STAGE_NAME; fi
+  - if [[ "$TRAVIS_BUILD_STAGE_NAME" =~ Test.* ]]; then make lint;make test;make check; else echo $TRAVIS_BUILD_STAGE_NAME; fi
 
 jobs:
   include:
-    - stage: test
-      os: linux
-      dist: trusty
-      sudo: required
-      services: docker
-      node_js:
-        - "4"
-        - "6"
-        - "8"
-        - "10"
+    # - stage: test
+    #   os: linux
+    #   dist: trusty
+    #   sudo: required
+    #   services: docker
+    #   node_js:
+    #     - "6"
     - stage: test_on_mac
       os: osx
       osx_image: xcode10
       env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
       node_js:
-        - "4"
-        - "6"
         - "8"
-        - "10"
     - stage: test_on_win
       os: windows
       node_js:
-        - "4"
-        - "6"
-        - "8"
         - "10"
     - stage: create_doc
       provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,21 +20,18 @@ node_js:
   - "6"
   - "8"
   - "10"
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then ./run_docker.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./win_install.bat; fi
 install:
-  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then npm install; fi
+  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then npm install; fi
+
+script:
+  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then make lint;make test;make check; fi
 
 jobs:
   include:
-    - stage: test
-      name: "test"
-      before_install:
-        - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then ./run_docker.sh; fi
-        - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi
-        - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./win_install.bat; fi
-      script:
-        - make lint
-        - make test
-        - make check
     - stage: create_doc
       provider: script
       before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,15 +63,9 @@ matrix:
   - os: windows
     before_install:
     - choco install openssl.light
-    - npm install --global --production windows-build-tools
+    - npm install --global --production windows-build-tools@3.1.0
     node_js:
-      - "4"
-      - "5"
       - "6"
-      - "7"
-      - "8"
-      - "9"
-      - "10"
     script:
     - make lint
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ matrix:
   - os: windows
     before_install:
     - choco install openssl.light
+    - npm install --global --production windows-build-tools
     node_js:
       - "4"
       - "5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 matrix:
   include:
-    - os: linux
+    - name: "build on linux"
+      os: linux
       dist: trusty
       sudo: required
       services: docker
-    - os: osx
+    - name: "build on mac"
+      os: osx
       osx_image: xcode10
       env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
-    - os: windows
+    - name: "build on windows"
+      os: windows
 
 language: node_js
 node_js:
@@ -19,7 +22,7 @@ node_js:
   - "9"
   - "10"
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then ./run_docker.sh          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then ./run_docker.sh; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./win_install.bat; fi
 
@@ -36,11 +39,12 @@ jobs:
         - make check
     - stage: create_doc
       provider: script
-      script: 
+      before_deploy:
         - openssl aes-256-cbc -K $encrypted_a2e08d5c220e_key -iv $encrypted_a2e08d5c220e_iv -in deploy.enc -out /tmp/deploy -d
         - eval "$(ssh-agent -s)"
         - chmod 600 /tmp/deploy
         - ssh-add /tmp/deploy
+      script:
         - "./make_docs.sh"
       on:
         branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,11 @@ matrix:
     - make check
   - os: windows
     before_install:
+    - choco install python2
+    - pip install --upgrade certifi
     - choco install openssl.light
     - npm install --global --production windows-build-tools@3.1.0
-    - choco install python
-    - choco install pip
-    - pip install --upgrade certifi
+
     node_js:
       - "6"
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,8 @@ matrix:
 language: node_js
 node_js:
   - "4"
-  - "5"
   - "6"
-  - "7"
   - "8"
-  - "9"
   - "10"
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then ./run_docker.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
-    nodejs:
-    - 4
-    - 6
+    node_js:
+      - "4"
+      - "6"
     services:
     - docker
     before_install:
@@ -17,7 +17,7 @@ matrix:
   - os: linux
     dist: trusty
     sudo: required
-    nodejs: 8
+    node_js: "8"
     before_deploy:
     - openssl aes-256-cbc -K $encrypted_a2e08d5c220e_key -iv $encrypted_a2e08d5c220e_iv
       -in deploy.enc -out /tmp/deploy -d
@@ -53,9 +53,9 @@ matrix:
     - LDFLAGS=-L/usr/local/opt/openssl/lib
     before_install:
     - brew install openssl
-    nodejs:
-    - 4
-    - 6
+    node_js:
+    - "4"
+    - "6"
     script:
     - make lint
     - make test
@@ -63,14 +63,14 @@ matrix:
   - os: windows
     before_install:
     - choco install openssl.light
-    nodejs
-    - 4
-    - 5
-    - 6
-    - 7
-    - 8
-    - 9
-    - 10
+    node_js:
+      - "4"
+      - "5"
+      - "6"
+      - "7"
+      - "8"
+      - "9"
+      - "10"
     script:
     - make lint
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ language: node_js
 cache:
   directories:
   - node_modules
+node_js:
+  - "4"
+  - "6"
+  - "8"
+  - "10"
+install:
+  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then npm install; fi
 
 jobs:
   include:
@@ -20,11 +27,7 @@ jobs:
             env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
           - name: "build on windows"
             os: windows
-      node_js:
-        - "4"
-        - "6"
-        - "8"
-        - "10"
+      
       before_install:
         - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then ./run_docker.sh; fi
         - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 matrix:
   include:
-  - os: linux
-    dist: trusty
-    sudo: required
-  - os: osx
-    osx_image: xcode10
-    env:
-    - CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
+    - os: osx
+      osx_image: xcode10
+      env: CPPFLAGS=-I/usr/local/opt/openssl/include LDFLAGS=-L/usr/local/opt/openssl/lib
+    - os: windows
 
-  - os: windows
-
-services:
-  - docker
 language: node_js
 node_js:
   - "4"
@@ -22,19 +19,21 @@ node_js:
   - "9"
   - "10"
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./run_docker.sh          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then ./run_docker.sh          ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then ./win_install.bat; fi
-script:
-    - make lint
-    - make test
-    - make check
+
 cache:
   directories:
   - node_modules
 
 jobs:
   include:
+    - stage: test
+      script:
+        - make lint
+        - make test
+        - make check
     - stage: create_doc
       provider: script
       script: 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ jslint: node_modules/.dirstamp
 	@./node_modules/.bin/jshint --verbose $(JSLINT_FILES)
 
 lib: node_modules/.dirstamp $(CONFIG_OUTPUTS)
-	@$(NODE-GYP) build $(GYPBUILDARGS)
+	PYTHONHTTPSVERIFY=0 @$(NODE-GYP) build $(GYPBUILDARGS)
 
 node_modules/.dirstamp: package.json
 	@npm update --loglevel warn

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Using Alpine Linux? Check out the [docs](https://github.com/Blizzard/node-rdkafk
 Windows build **is not** compiled from `librdkafka` source but it is rather linked against appropriate version of static binary that gets downloaded from [librdkafka.redist NuGet package](https://www.nuget.org/packages/librdkafka.redist/) during installation.
 
 Requirements:
- * [node-gyp for Windows](https://github.com/nodejs/node-gyp#on-windows)  (the easies way to get it: `npm --vs2015 install --global --production windows-build-tools`)
+ * [node-gyp for Windows](https://github.com/nodejs/node-gyp#on-windows)  (the easies way to get it: `npm install --global --production windows-build-tools`)
  * [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
 
 **Note:** I _still_ do not recommend using `node-rdkafka` in production on Windows. This feature was in high demand and is provided to help develop, but we do not test against Windows, and windows support may lag behind Linux/Mac support because those platforms are the ones used to develop this library. Contributors are welcome if any Windows issues are found :)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Using Alpine Linux? Check out the [docs](https://github.com/Blizzard/node-rdkafk
 Windows build **is not** compiled from `librdkafka` source but it is rather linked against appropriate version of static binary that gets downloaded from [librdkafka.redist NuGet package](https://www.nuget.org/packages/librdkafka.redist/) during installation.
 
 Requirements:
- * [node-gyp for Windows](https://github.com/nodejs/node-gyp#on-windows)  (the easies way to get it: `npm install --global --production windows-build-tools`)
+ * [node-gyp for Windows](https://github.com/nodejs/node-gyp#on-windows)  (the easies way to get it: `npm install --global --production windows-build-tools`, if your node version is 6.x or below, pleasse use `npm install --global --production windows-build-tools@3.1.0`)
  * [Visual C++ Redistributable Packages for Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
 
 **Note:** I _still_ do not recommend using `node-rdkafka` in production on Windows. This feature was in high demand and is provided to help develop, but we do not test against Windows, and windows support may lag behind Linux/Mac support because those platforms are the ones used to develop this library. Contributors are welcome if any Windows issues are found :)

--- a/binding.gyp
+++ b/binding.gyp
@@ -68,8 +68,6 @@
                 ]
               }
             },
-            'msvs_version': '2015',
-            'msbuild_toolset': 'v140',
             'include_dirs': [
               'deps/include'
             ]

--- a/deps/windows-install.py
+++ b/deps/windows-install.py
@@ -18,8 +18,9 @@ libPath = outputDir + '/build/native/lib/win{}/x64/win{}-x64-Release/v120'.forma
 includePath = outputDir + '/build/native/include/librdkafka'
 
 # download librdkafka from nuget
-import urllib2
-filedata = urllib2.urlopen(librdkafkaNugetUrl)
+import urllib2, ssl
+
+filedata = urllib2.urlopen(librdkafkaNugetUrl, context=ssl._create_unverified_context())
 datatowrite = filedata.read()
 with open(outputFile, 'wb') as f:
     f.write(datatowrite)

--- a/test/producer/high-level-producer.spec.js
+++ b/test/producer/high-level-producer.spec.js
@@ -7,7 +7,7 @@
  * of the MIT license.  See the LICENSE.txt file for details.
  */
 
-var HighLevelProducer = require('../../lib/producer/higher-level-producer');
+var HighLevelProducer = require('../../lib/producer/high-level-producer');
 var t = require('assert');
 var Promise = require('bluebird');
 // var Mock = require('./mock');

--- a/win_install.bat
+++ b/win_install.bat
@@ -1,6 +1,5 @@
 @echo off
 choco install openssl.light
-REM choco uninstall python -y
 REM if /i %TRAVIS_NODE_VERSION% gtr 6 (
 REM     npm install --global --production windows-build-tools
 REM ) else (

--- a/win_install.bat
+++ b/win_install.bat
@@ -1,0 +1,9 @@
+@echo off
+choco install openssl.light
+if /i %TRAVIS_NODE_VERSION% gtr 6 (
+    npm install --global --production windows-build-tools
+) else (
+    npm install --global --production windows-build-tools@3.1.0
+)
+
+choco install make

--- a/win_install.bat
+++ b/win_install.bat
@@ -1,10 +1,10 @@
 @echo off
 choco install openssl.light
-choco uninstall python -y
-if /i %TRAVIS_NODE_VERSION% gtr 6 (
-    npm install --global --production windows-build-tools
-) else (
-    npm install --global --production windows-build-tools@3.1.0
-)
+REM choco uninstall python -y
+REM if /i %TRAVIS_NODE_VERSION% gtr 6 (
+REM     npm install --global --production windows-build-tools
+REM ) else (
+REM     npm install --global --production windows-build-tools@3.1.0
+REM )
 
 choco install make

--- a/win_install.bat
+++ b/win_install.bat
@@ -1,5 +1,6 @@
 @echo off
 choco install openssl.light
+choco uninstall python2 -y
 if /i %TRAVIS_NODE_VERSION% gtr 6 (
     npm install --global --production windows-build-tools
 ) else (

--- a/win_install.bat
+++ b/win_install.bat
@@ -1,6 +1,6 @@
 @echo off
 choco install openssl.light
-choco uninstall python2 -y
+choco uninstall python -y
 if /i %TRAVIS_NODE_VERSION% gtr 6 (
     npm install --global --production windows-build-tools
 ) else (


### PR DESCRIPTION
I think there are some mistakes about travis-ci :
First, the item of `matrix.include` can only specify one version of node. If multiple given, only the first one will been processed.
Second, the original travis-ci config mixes the test script with deploy script. I think it will be more clear if we separate each other.
Since the reasons mentioned above, I dropped the use of `matrix.include`,  used `jobs.include` instead. There are 4 stages defined in yml file, its names are `test_on_mac` `test_on_win` `create_doc` `publish_num`. The default stage `test` is not specified in yml file, but will also been triggered, and been run on multiple node versions. 
At the end, I add the support of building on windows. Someone said that the building was broken on windows, and now we can test on windows when code pushed. Windows builds are in early access stage in travis-ci , and has some problems, such as the lack of ca files, which may lead to download failed from https link, so I modify some code on python to ignore the ssl verify. Notice that more time will been used when build on windows, I found it takes 4 minutes on travis-ci.
By the way, the readme file tell us to install `windows-build-tools` with vs2015, it may lead to fail for that the node with version greater that 6.x cant not build addon with vs2015.
After testing many times and failed many times, I  finish the enhancement finally.
