### PR TITLE
Fix backwards compatibility problem in node-rdkafka

### DIFF
--- a/ci/checks/librdkafka-correct-version.js
+++ b/ci/checks/librdkafka-correct-version.js
@@ -41,21 +41,31 @@ function parseLibrdkafkaVersion(version) {
   const patch = (intRepresentation & patchMask) >> (8 * 1);
   const rev = (intRepresentation & revMask) >> (8 * 0);
 
-  return {
+  const output = {
     major,
     minor,
     patch,
-    rev
   };
+
+  if (rev !== 255) {
+    output.rev = rev;
+  }
+
+  return output;
 }
 
 function versionAsString(version) {
-  return [
+  const versionItems = [
     version.major,
     version.minor,
-    version.patch,
-    version.rev
-  ].join('.');
+    version.patch
+  ];
+
+  if (version.rev) {
+    versionItems.push(version);
+  }
+
+  return versionItems.join('.');
 }
 
 const librdkafkaVersion = parseLibrdkafkaVersion(defines.RD_KAFKA_VERSION);

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -164,7 +164,7 @@ describe('Consumer/Producer', function() {
 
     });
   });
-  
+
   it('should return ready messages on partition EOF', function(done) {
     this.timeout(8000);
     crypto.randomBytes(4096, function(ex, buffer) {
@@ -282,7 +282,7 @@ describe('Consumer/Producer', function() {
     this.timeout(5000);
     run_headers_test(done, headers);
   });
-  
+
   it('should be able to produce and consume messages with multiple headers value as string: consumeLoop', function(done) {
     var headers = [
       { key1: 'value1' },
@@ -393,7 +393,7 @@ describe('Consumer/Producer', function() {
         lastOffset = message.offset;
 
         // disconnect in offset commit callback
-        consumer.on('offset.commit', function(err, offsets) {
+        consumer.on('offsetCommit', function(err, offsets) {
           t.ifError(err);
           t.equal(typeof offsets, 'object', 'offsets should be returned');
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,8 @@ export class Client extends NodeJS.EventEmitter {
     on(event: 'delivery-report', listener: (error: Error, report: any) => void): this;
 
     // offsets
-    on(event: 'offset.commit', listener: (error: Error, topicPartitions: any[]) => void): this;
+    on(event: 'offset.commit', listener: (topicPartitions: any[]) => void): this;
+    on(event: 'offsetCommit', listener: (error: Error, topicPartitions: any[]) => void): this;
 
 // ONCE
     // domain events

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -93,12 +93,16 @@ function KafkaConsumer(conf, topicConf) {
   if (onOffsetCommit && typeof onOffsetCommit === 'boolean') {
     conf.offset_commit_cb = function(err, offsets) {
       // Emit the event
-      self.emit('offset.commit', err, offsets);
+      self.emit('offset.commit', offsets);
+      // Stay backwards compatible for now
+      self.emit('offsetCommit', err, offsets);
     };
   } else if (onOffsetCommit && typeof onOffsetCommit === 'function') {
     conf.offset_commit_cb = function(err, offsets) {
       // Emit the event
-      self.emit('offset.commit', err, offsets);
+      self.emit('offset.commit', offsets);
+      // Stay backwards compatible for now
+      self.emit('offsetCommit', err, offsets);
       onOffsetCommit.call(self, err, offsets);
     };
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-rdkafka",
   "version": "v2.7.0-2",
   "description": "Node.js bindings for librdkafka",
-  "librdkafka": "1.0.0.2",
+  "librdkafka": "1.0.1",
   "main": "lib/index.js",
   "scripts": {
     "configure": "node-gyp configure",


### PR DESCRIPTION
This uses the next level syntax for events which will be camelCase instead of dot separated.