### PR TITLE
Allow compatibility with AWS Lambda Layers

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -113,7 +113,8 @@
                   "libraries": ["-lrdkafka", "-lrdkafka++"],
                   "include_dirs": [
                     "/usr/include/librdkafka",
-                    "/usr/local/include/librdkafka"
+                    "/usr/local/include/librdkafka",
+                    "/opt/include/librdkafka",
                   ],
                 },
               ],


### PR DESCRIPTION
From: https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html

The hard-coded paths for the linux linked build cannot be exploited with AWS Lambda's Layers style of building dependencies into a deployable asset.

If one was to create a layer they'd need to install `librdkafka` and set the prefix-path as `./configure --prefix="/opt"` which would result in `/opt/includes/librdkafka` having the header files. 

I've just added this to the array for now so we could potentially consume/publish as a part of an AWS StepFunctions or Lambda heavy workflow.

Happy to discuss - feels like there's a better solution to acquire the includepaths out there somewhere.