### PR TITLE
Update librdkafka to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I am looking for *your* help to make this project even better! If you're interes
 
 The `node-rdkafka` library is a high-performance NodeJS client for [Apache Kafka](http://kafka.apache.org/) that wraps the native  [librdkafka](https://github.com/edenhill/librdkafka) library.  All the complexity of balancing writes across partitions and managing (possibly ever-changing) brokers should be encapsulated in the library.
 
-__This library currently uses `librdkafka` version `0.11.6`.__
+__This library currently uses `librdkafka` version `1.1.0`.__
 
 ## Reference Docs
 
@@ -96,7 +96,7 @@ var Kafka = require('node-rdkafka');
 
 ## Configuration
 
-You can pass many configuration options to `librdkafka`.  A full list can be found in `librdkafka`'s [Configuration.md](https://github.com/edenhill/librdkafka/blob/v0.11.6/CONFIGURATION.md)
+You can pass many configuration options to `librdkafka`.  A full list can be found in `librdkafka`'s [Configuration.md](https://github.com/edenhill/librdkafka/blob/v1.1.0/CONFIGURATION.md)
 
 Configuration keys that have the suffix `_cb` are designated as callbacks. Some
 of these keys are informational and you can choose to opt-in (for example, `dr_cb`). Others are callbacks designed to
@@ -131,7 +131,7 @@ You can also get the version of `librdkafka`
 const Kafka = require('node-rdkafka');
 console.log(Kafka.librdkafkaVersion);
 
-// #=> 0.11.1
+// #=> 1.1.0
 ```
 
 ## Sending Messages
@@ -144,7 +144,7 @@ var producer = new Kafka.Producer({
 });
 ```
 
-A `Producer` requires only `metadata.broker.list` (the Kafka brokers) to be created.  The values in this list are separated by commas.  For other configuration options, see the [Configuration.md](https://github.com/edenhill/librdkafka/blob/0.11.1.x/CONFIGURATION.md) file described previously.
+A `Producer` requires only `metadata.broker.list` (the Kafka brokers) to be created.  The values in this list are separated by commas.  For other configuration options, see the [Configuration.md](https://github.com/edenhill/librdkafka/blob/1.1.0/CONFIGURATION.md) file described previously.
 
 The following example illustrates a list with several `librdkafka` options set.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-rdkafka",
   "version": "v2.7.0-2",
   "description": "Node.js bindings for librdkafka",
-  "librdkafka": "1.0.0.2",
+  "librdkafka": "1.1.0",
   "main": "lib/index.js",
   "scripts": {
     "configure": "node-gyp configure",


### PR DESCRIPTION
This PR bumps the `librdkafka` version to 1.1.0, release notes are here: https://github.com/edenhill/librdkafka/releases/tag/v1.1.0

I'm not sure if we just want to bump or perhaps make appropriate changes to match new configuration properties as of 1.1.0.

✌️ 