### PR TITLE
Fix CI - librdkafka from nuget

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-rdkafka",
   "version": "v2.7.0-2",
   "description": "Node.js bindings for librdkafka",
-  "librdkafka": "1.0.0.2",
+  "librdkafka": "1.0.1",
   "main": "lib/index.js",
   "scripts": {
     "configure": "node-gyp configure",


### PR DESCRIPTION
According to #627, upgrade in `package.json` _librdkafka_ version.
The bug was librdkafka.redist doesn't exists in version `1.0.0.2` - https://www.nuget.org/packages/librdkafka.redist/