### PR TITLE
Fix bug where the timeout in the admin APIs wasn't taken into account.

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -109,7 +109,8 @@ AdminClient.prototype.disconnect = function() {
  * Create a topic with a given config.
  *
  * @param {NewTopic} topic - Topic to create.
- * @param {number} timeout - Number of milliseconds to wait while trying to create the topic.
+ * @param {number} timeout - Number of milliseconds to wait while trying to create the topic, rounded down to the second. 
+ *                           In addition, a timeout under 1000 ms will be rounded to 1000ms.
  * @param {function} cb - The callback to be executed when finished
  */
 AdminClient.prototype.createTopic = function(topic, timeout, cb) {
@@ -122,7 +123,7 @@ AdminClient.prototype.createTopic = function(topic, timeout, cb) {
     timeout = 1000;
   }
 
-  if (!timeout) {
+  if (!timeout || timeout < 1000) {
     timeout = 1000;
   }
 
@@ -144,7 +145,8 @@ AdminClient.prototype.createTopic = function(topic, timeout, cb) {
  * Delete a topic.
  *
  * @param {string} topic - The topic to delete, by name.
- * @param {number} timeout - Number of milliseconds to wait while trying to delete the topic.
+ * @param {number} timeout - Number of milliseconds to wait while trying to delete the topic, rounded down to the second. 
+ *                           In addition, a timeout under 1000 ms will be rounded to 1000ms.
  * @param {function} cb - The callback to be executed when finished
  */
 AdminClient.prototype.deleteTopic = function(topic, timeout, cb) {
@@ -157,7 +159,7 @@ AdminClient.prototype.deleteTopic = function(topic, timeout, cb) {
     timeout = 1000;
   }
 
-  if (!timeout) {
+  if (!timeout || timeout < 1000) {
     timeout = 1000;
   }
 
@@ -181,7 +183,8 @@ AdminClient.prototype.deleteTopic = function(topic, timeout, cb) {
  * @param {string} topic - The topic to add partitions to, by name.
  * @param {number} totalPartitions - The total number of partitions the topic should have
  *                                   after the request
- * @param {number} timeout - Number of milliseconds to wait while trying to delete the topic.
+ * @param {number} timeout - Number of milliseconds to wait while trying to create the partitions, rounded down to the second. 
+ *                           In addition, a timeout under 1000 ms will be rounded to 1000ms.
  * @param {function} cb - The callback to be executed when finished
  */
 AdminClient.prototype.createPartitions = function(topic, totalPartitions, timeout, cb) {
@@ -194,7 +197,7 @@ AdminClient.prototype.createPartitions = function(topic, totalPartitions, timeou
     timeout = 1000;
   }
 
-  if (!timeout) {
+  if (!timeout || timeout < 1000) {
     timeout = 1000;
   }
 

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -109,8 +109,7 @@ AdminClient.prototype.disconnect = function() {
  * Create a topic with a given config.
  *
  * @param {NewTopic} topic - Topic to create.
- * @param {number} timeout - Number of milliseconds to wait while trying to create the topic, rounded down to the second. 
- *                           In addition, a timeout under 1000 ms will be rounded to 1000ms.
+ * @param {number} timeout - Number of milliseconds to wait while trying to create the topic.
  * @param {function} cb - The callback to be executed when finished
  */
 AdminClient.prototype.createTopic = function(topic, timeout, cb) {
@@ -120,11 +119,11 @@ AdminClient.prototype.createTopic = function(topic, timeout, cb) {
 
   if (typeof timeout === 'function') {
     cb = timeout;
-    timeout = 1000;
+    timeout = 5000;
   }
 
-  if (!timeout || timeout < 1000) {
-    timeout = 1000;
+  if (!timeout) {
+    timeout = 5000;
   }
 
   this._client.createTopic(topic, timeout, function(err) {
@@ -145,8 +144,7 @@ AdminClient.prototype.createTopic = function(topic, timeout, cb) {
  * Delete a topic.
  *
  * @param {string} topic - The topic to delete, by name.
- * @param {number} timeout - Number of milliseconds to wait while trying to delete the topic, rounded down to the second. 
- *                           In addition, a timeout under 1000 ms will be rounded to 1000ms.
+ * @param {number} timeout - Number of milliseconds to wait while trying to delete the topic.
  * @param {function} cb - The callback to be executed when finished
  */
 AdminClient.prototype.deleteTopic = function(topic, timeout, cb) {
@@ -156,11 +154,11 @@ AdminClient.prototype.deleteTopic = function(topic, timeout, cb) {
 
   if (typeof timeout === 'function') {
     cb = timeout;
-    timeout = 1000;
+    timeout = 5000;
   }
 
-  if (!timeout || timeout < 1000) {
-    timeout = 1000;
+  if (!timeout) {
+    timeout = 5000;
   }
 
   this._client.deleteTopic(topic, timeout, function(err) {
@@ -183,8 +181,7 @@ AdminClient.prototype.deleteTopic = function(topic, timeout, cb) {
  * @param {string} topic - The topic to add partitions to, by name.
  * @param {number} totalPartitions - The total number of partitions the topic should have
  *                                   after the request
- * @param {number} timeout - Number of milliseconds to wait while trying to create the partitions, rounded down to the second. 
- *                           In addition, a timeout under 1000 ms will be rounded to 1000ms.
+ * @param {number} timeout - Number of milliseconds to wait while trying to create the partitions.
  * @param {function} cb - The callback to be executed when finished
  */
 AdminClient.prototype.createPartitions = function(topic, totalPartitions, timeout, cb) {
@@ -194,11 +191,11 @@ AdminClient.prototype.createPartitions = function(topic, totalPartitions, timeou
 
   if (typeof timeout === 'function') {
     cb = timeout;
-    timeout = 1000;
+    timeout = 5000;
   }
 
-  if (!timeout || timeout < 1000) {
-    timeout = 1000;
+  if (!timeout) {
+    timeout = 5000;
   }
 
   this._client.createPartitions(topic, totalPartitions, timeout, function(err) {

--- a/src/admin.cc
+++ b/src/admin.cc
@@ -200,12 +200,18 @@ Baton AdminClient::CreateTopic(rd_kafka_NewTopic_t* topic, int timeout_ms) {
 
     rd_kafka_CreateTopics(m_client->c_ptr(), &topic, 1, options, topic_rkqu);
 
+    // The number of tries is dependent on the timeout
+    // the user asked and the polling timeout.
+    // Timeout will be rounded down to the second.
+    const int pollingTimeout = 1000;
+    const int max_tries = timeout_ms / pollingTimeout;
+
     // Poll for an event by type in that queue
     rd_kafka_event_t * event_response = PollForEvent(
       topic_rkqu,
       RD_KAFKA_EVENT_CREATETOPICS_RESULT,
-      5,
-      1000);
+      max_tries,
+      pollingTimeout);
 
     // Destroy the queue since we are done with it.
     rd_kafka_queue_destroy(topic_rkqu);
@@ -280,12 +286,18 @@ Baton AdminClient::DeleteTopic(rd_kafka_DeleteTopic_t* topic, int timeout_ms) {
 
     rd_kafka_DeleteTopics(m_client->c_ptr(), &topic, 1, options, topic_rkqu);
 
+    // The number of tries is dependent on the timeout
+    // the user asked and the polling timeout.
+    // Timeout will be rounded down to the second.
+    const int pollingTimeout = 1000;
+    const int max_tries = timeout_ms / pollingTimeout;
+
     // Poll for an event by type in that queue
     rd_kafka_event_t * event_response = PollForEvent(
       topic_rkqu,
       RD_KAFKA_EVENT_DELETETOPICS_RESULT,
-      5,
-      1000);
+      max_tries,
+      pollingTimeout);
 
     // Destroy the queue since we are done with it.
     rd_kafka_queue_destroy(topic_rkqu);
@@ -356,12 +368,18 @@ Baton AdminClient::CreatePartitions(
     rd_kafka_CreatePartitions(m_client->c_ptr(),
       &partitions, 1, options, topic_rkqu);
 
+    // The number of tries is dependent on the timeout
+    // the user asked and the polling timeout.
+    // Timeout will be rounded down to the second.
+    const int pollingTimeout = 1000;
+    const int max_tries = timeout_ms / pollingTimeout;
+
     // Poll for an event by type in that queue
     rd_kafka_event_t * event_response = PollForEvent(
       topic_rkqu,
       RD_KAFKA_EVENT_CREATEPARTITIONS_RESULT,
-      5,
-      1000);
+      max_tries,
+      pollingTimeout);
 
     // Destroy the queue since we are done with it.
     rd_kafka_queue_destroy(topic_rkqu);

--- a/src/admin.cc
+++ b/src/admin.cc
@@ -568,6 +568,9 @@ NAN_METHOD(AdminClient::NodeCreatePartitions) {
   Nan::Callback *callback = new Nan::Callback(cb);
   AdminClient* client = ObjectWrap::Unwrap<AdminClient>(info.This());
 
+  // Get the timeout
+  int timeout = Nan::To<int32_t>(info[2]).FromJust();
+
   // Get the total number of desired partitions
   int partition_total_count = Nan::To<int32_t>(info[1]).FromJust();
 


### PR DESCRIPTION
The timeout_ms parameter for the admin APIs wasn't being used anywhere.
With that change, the parameter is now used to determine how many times we are going to poll for the given event.
I didn't change the polling timeout (1000ms) so I had to make a decision to round down to the second (i.e. 1800ms would be rounded down to 1sec) and also overriding any value < 1000 to 1000.

Since that parameter wasn't being used yet, another solution would be to change the granularity from ms to sec in the function (timeout_sec instead of timeout_ms). This would prevent the rounding down and the minimum value tricks.