### PR TITLE
Update Producer.produce TypeScript signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -130,7 +130,7 @@ export class Producer extends Client {
 
     poll(): any;
 
-    produce(topic: any, partition: any, message: any, key?: any, timestamp?: any, opaque?: any): any;
+    produce(topic: any, partition: any, message: any, key?: any, timestamp?: any, opaque?: any, headers?: any): any;
 
     setPollInterval(interval: any): any;
 


### PR DESCRIPTION
It's missing the headers parameter, which means if you want to send headers using
`node-rdkafka` from TypeScript, you have to any-cast the producer, or extend w/
your own typings.