### PR TITLE
Stop the build with error if lint step fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - if [[ "$TRAVIS_BUILD_STAGE_NAME" =~ Test.* ]]; then npm install; fi
 
 script:
-  - if [[ "$TRAVIS_BUILD_STAGE_NAME" =~ Test.* ]]; then make lint;make test;make check; else echo $TRAVIS_BUILD_STAGE_NAME; fi
+  - if [[ "$TRAVIS_BUILD_STAGE_NAME" =~ Test.* ]]; then make lint && make test && make check; else echo $TRAVIS_BUILD_STAGE_NAME; fi
 
 jobs:
   include:

--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -169,8 +169,9 @@ Baton KafkaConsumer::Assign(std::vector<RdKafka::TopicPartition*> partitions) {
     m_partitions.swap(partitions);
   }
 
-  // Destroy the partitions: Either we're using them (and partitions is now our old vector), or
-  // we're not using it as there was an error.
+  // Destroy the partitions: Either we're using them (and partitions
+  // is now our old vector), or we're not using it as there was an
+  // error.
   RdKafka::TopicPartition::destroy(partitions);
 
   return Baton(errcode);


### PR DESCRIPTION
Refactoring .travis.yml and Makefile caused regression in #609,
which no longer stops the build if previous lint or test step with
make fails.