### PR TITLE
Add type for Producer.createWriteStream

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -134,6 +134,7 @@ export class Producer extends Client {
 
     setPollInterval(interval: any): any;
 
+    static createWriteStream(conf: any, topicConf: any, streamOptions: any): any;
 }
 
 export class HighLevelProducer extends Producer {


### PR DESCRIPTION
Update TypeScript type declaration file to include definiton of
Prouder.createWriteStream method.

Fixes: https://github.com/Blizzard/node-rdkafka/issues/724