### PR TITLE
Fix/cpplint tidy up

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -113,6 +113,8 @@ export class KafkaConsumer extends Client {
 
     setDefaultConsumeTimeout(timeoutMs: any): void;
 
+    setDefaultConsumeTotalTimeout(timeoutMs: any): void;
+
     subscribe(topics: string[]): this;
 
     subscription(): ErrorWrap<any>;

--- a/lib/client.js
+++ b/lib/client.js
@@ -83,6 +83,7 @@ function Client(globalConf, SubClientType, topicConf) {
 
   this.metrics = {};
   this._isConnected = false;
+  this._isDisconnecting = false;
   this.errorCounter = 0;
 
   /**
@@ -254,6 +255,15 @@ Client.prototype.isConnected = function() {
   return !!(this._isConnected && this._client);
 };
 
+/**
+ * Whether or not we are disconnecting from Kafka.
+ *
+ * @return {boolean} - Whether we are disconnecting.
+ */
+Client.prototype.isDisconnecting = function() {
+    return !!(this._isDisconnecting && this._client);
+  };
+  
 /**
  * Get the last error emitted if it exists.
  *

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -125,6 +125,7 @@ function KafkaConsumer(conf, topicConf) {
   this.topicConfig = topicConf;
 
   this._consumeTimeout = 1000;
+  this._consumeTotalTimeout = 1000;
 }
 
 /**
@@ -132,9 +133,17 @@ function KafkaConsumer(conf, topicConf) {
  * @param {number} timeoutMs - number of milliseconds to wait for a message to be fetched
  */
 KafkaConsumer.prototype.setDefaultConsumeTimeout = function(timeoutMs) {
-  this._consumeTimeout = timeoutMs;
+    this._consumeTimeout = timeoutMs;
 };
 
+/**
+ * Set the default total consume timeout provided to c++land
+ * @param {number} timeoutMs - number of milliseconds to wait for total message(s) to be fetched
+ */
+KafkaConsumer.prototype.setDefaultConsumeTotalTimeout = function(timeoutMs) {
+    this._consumeTotalTimeout = timeoutMs;
+};
+  
 /**
  * Get a stream representation of this KafkaConsumer
  *
@@ -370,6 +379,7 @@ KafkaConsumer.prototype.unsubscribe = function() {
  */
 KafkaConsumer.prototype.consume = function(number, cb) {
   var timeoutMs = this._consumeTimeout || 1000;
+  var timeoutTotalMs = this._consumeTotalTimeout || 1000;
   var self = this;
 
   if ((number && typeof number === 'number') || (number && cb)) {
@@ -380,7 +390,7 @@ KafkaConsumer.prototype.consume = function(number, cb) {
       throw new TypeError('Callback must be a function');
     }
 
-    this._consumeNum(timeoutMs, number, cb);
+    this._consumeNum(timeoutMs, timeoutTotalMs, number, cb);
   } else {
 
     // See https://github.com/Blizzard/node-rdkafka/issues/220
@@ -440,10 +450,10 @@ KafkaConsumer.prototype._consumeLoop = function(timeoutMs, cb) {
  * @private
  * @see consume
  */
-KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, cb) {
+KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, timeoutTotalMs, cb) {
   var self = this;
 
-  this._client.consume(timeoutMs, numMessages, function(err, messages) {
+  this._client.consume(timeoutMs, numMessages, timeoutTotalMs, function(err, messages) {
     if (err) {
       err = LibrdKafkaError.create(err);
       if (cb) {

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -390,7 +390,7 @@ KafkaConsumer.prototype.consume = function(number, cb) {
       throw new TypeError('Callback must be a function');
     }
 
-    this._consumeNum(timeoutMs, timeoutTotalMs, number, cb);
+    this._consumeNum(timeoutMs, number, timeoutTotalMs, cb);
   } else {
 
     // See https://github.com/Blizzard/node-rdkafka/issues/220

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "configure": "node-gyp configure",
     "build": "node-gyp build",
     "test": "make test",
-    "install": "node-gyp rebuild",
-    "prepack": "node ./ci/prepublish.js"
+    "install": "node-gyp rebuild"
   },
   "keywords": [
     "kafka",

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -525,7 +525,7 @@ KafkaConsumerConsumeNum::~KafkaConsumerConsumeNum() {}
 uint32_t getTick() {
     struct timespec ts;
     unsigned theTick = 0U;
-    clock_gettime( CLOCK_MONOTONIC, &ts );
+    clock_gettime(CLOCK_MONOTONIC, &ts);
     theTick  = ts.tv_nsec / 1000000;
     theTick += ts.tv_sec * 1000;
     return theTick;
@@ -541,34 +541,31 @@ void KafkaConsumerConsumeNum::Execute() {
   #ifndef _WIN32
     struct timespec ts;
     unsigned start = 0U;
-    clock_gettime( CLOCK_MONOTONIC, &ts );
+    clock_gettime(CLOCK_MONOTONIC, &ts);
     start  = ts.tv_nsec / 1000000;
     start += ts.tv_sec * 1000;
   #else
-  long int start = GetTickCount();
+    int start = GetTickCount();
   #endif
 
   while (m_messages.size() < max && looping) {
     // Get a message
-    // TODO: Create a new property like setDefaultConsumeTimeout(), called setDefaultConsumeTotalTimeout()
-    // For now, we use the default consume timeout as total, and the actual consume timeout is total / 10
-    // Eg for a value of 1000ms, we consume every 100ms.
     Baton b = m_consumer->Consume(timeout_ms);
     #ifndef _WIN32
     unsigned end = 0U;
-    clock_gettime( CLOCK_MONOTONIC, &ts );
+    clock_gettime(CLOCK_MONOTONIC, &ts);
     end  = ts.tv_nsec / 1000000;
     end += ts.tv_sec * 1000;
-	unsigned elapsed = (end - start);
-	if (elapsed >= toal_timeout_ms) {
-	  looping = false;
-	}
+    unsigned elapsed = (end - start);
+    if (elapsed >= toal_timeout_ms) {
+        looping = false;
+    }
     #else
-	long int end = GetTickCount();
-	long elapsed = (end - start);
-	if (elapsed >= toal_timeout_ms) {
-	  looping = false;
-	}
+    int end = GetTickCount();
+    int elapsed = (end - start);
+    if (elapsed >= toal_timeout_ms) {
+        looping = false;
+    }
     #endif
     switch (b.err()) {
       case RdKafka::ERR__PARTITION_EOF:

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -517,7 +517,7 @@ KafkaConsumerConsumeNum::KafkaConsumerConsumeNum(Nan::Callback *callback,
   ErrorAwareWorker(callback),
   m_consumer(consumer),
   m_num_messages(num_messages),
-  m_timeout_ms(timeout_ms) {}
+  m_timeout_ms(timeout_ms),
   m_total_timeout_ms(total_timeout_ms) {}
 
 KafkaConsumerConsumeNum::~KafkaConsumerConsumeNum() {}

--- a/src/workers.h
+++ b/src/workers.h
@@ -338,7 +338,7 @@ class KafkaConsumerSeek : public ErrorAwareWorker {
 class KafkaConsumerConsumeNum : public ErrorAwareWorker {
  public:
   KafkaConsumerConsumeNum(Nan::Callback*, NodeKafka::KafkaConsumer*,
-    const uint32_t &, const int &);
+    const uint32_t &, const int &, const int &);
   ~KafkaConsumerConsumeNum();
 
   void Execute();

--- a/src/workers.h
+++ b/src/workers.h
@@ -348,6 +348,7 @@ class KafkaConsumerConsumeNum : public ErrorAwareWorker {
   NodeKafka::KafkaConsumer * m_consumer;
   const uint32_t m_num_messages;
   const int m_timeout_ms;
+  const int m_total_timeout_ms;
   std::vector<RdKafka::Message*> m_messages;
 };
 


### PR DESCRIPTION
This PR:
- exposes the isDisconnecting flag so the application can manage the lifecycle of the library
- introduces a new option called Consume Total Timeout, default value is 1000ms
- removes prepack script so we can actually include branches from package.json