### PR TITLE
Add support for python 2 and 3 when installing on Windows

### DIFF
--- a/deps/windows-install.py
+++ b/deps/windows-install.py
@@ -18,9 +18,16 @@ libPath = outputDir + '/build/native/lib/win{}/x64/win{}-x64-Release/v120'.forma
 includePath = outputDir + '/build/native/include/librdkafka'
 
 # download librdkafka from nuget
-import urllib2, ssl
+try:
+    # For Python 3.0 and later
+    from urllib.request import urlopen
+except ImportError:
+    # Fall back to Python 2's urllib2
+    from urllib2 import urlopen
+import ssl
 
-filedata = urllib2.urlopen(librdkafkaNugetUrl, context=ssl._create_unverified_context())
+filedata = urlopen(librdkafkaNugetUrl, context=ssl._create_unverified_context())
+
 datatowrite = filedata.read()
 with open(outputFile, 'wb') as f:
     f.write(datatowrite)


### PR DESCRIPTION
When installing node-rdkafka on Windows, if `python` on your PATH points to python 3, the installation fails with an error about being unable to import urllib2. This PR changes the installation script so it tries to import the python 3 module first, and fall back on the python 2 module. This will allow installation regardless of the python version you have as your default.