### PR TITLE
add createReadStream to KafkaConsumer type def

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,8 +100,6 @@ export class KafkaConsumer extends Client {
     consume(number: number, cb?: any): void;
     consume(): void;
 
-    static createReadStream: (conf: any, topicConf: any, streamOptions: any) => ConsumerStream;
-
     getWatermarkOffsets(topic: any, partition: any): ErrorWrap<any>;
 
     offsetsStore(topicPartitions: any): ErrorWrap<any>;
@@ -124,7 +122,7 @@ export class KafkaConsumer extends Client {
 
     unsubscribe(): this;
 
-    createReadStream(conf: any, topicConfig: any, streamOptions: any): ConsumerStream;
+    static createReadStream(conf: any, topicConfig: any, streamOptions: any): ConsumerStream;
 }
 
 export class Producer extends Client {

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,8 @@ export class KafkaConsumer extends Client {
     consume(number: number, cb?: any): void;
     consume(): void;
 
+    static createReadStream: (conf: any, topicConf: any, streamOptions: any) => ConsumerStream;
+
     getWatermarkOffsets(topic: any, partition: any): ErrorWrap<any>;
 
     offsetsStore(topicPartitions: any): ErrorWrap<any>;


### PR DESCRIPTION
Adds this missing definition from the `KafkaConsumer` API: https://github.com/Blizzard/node-rdkafka/blob/50ca65778c2295a690683857aa84522639be87a2/lib/kafka-consumer.js#L158