### PR TITLE
index.d.ts broken

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import { Readable, Writable } from 'stream';
+import { EventEmitter } from 'events';
 
-export class Client extends NodeJS.EventEmitter {
+export class Client extends EventEmitter {
     constructor(globalConf: any, SubClientType: any, topicConf: any);
 
     connect(metadataOptions?: any, cb?: (err: any, data: any) => any): this;
@@ -121,6 +122,7 @@ export class KafkaConsumer extends Client {
 
     unsubscribe(): this;
 
+    createReadStream(conf: any, topicConfig: any, streamOptions: any): ConsumerStream;
 }
 
 export class Producer extends Client {
@@ -134,7 +136,7 @@ export class Producer extends Client {
 
     setPollInterval(interval: any): any;
 
-    static createWriteStream(conf: any, topicConf: any, streamOptions: any): any;
+    static createWriteStream(conf: any, topicConf: any, streamOptions: any): ProducerStream;
 }
 
 export class HighLevelProducer extends Producer {


### PR DESCRIPTION
Package wont be able to compile with ts due to changes in DefinitelyTyped/DefinitelyTyped#40927

Up version after merge pls. This is very critical.
-------
Fix error with EventEmitter caused by DefinitelyTyped/DefinitelyTyped#40927
Add type for KafkaConsumer.createReadStream
Fix return type for Producer.createWriteStream