### PR TITLE
Support Node.js 13.x 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ node_js:
   - "8"
   - "10"
   - "12"
+  - "13"
 sudo: required
 services: docker
 before_install:

--- a/src/admin.cc
+++ b/src/admin.cc
@@ -90,8 +90,8 @@ void AdminClient::Init(v8::Local<v8::Object> exports) {
 
   constructor.Reset(
     (tpl->GetFunction(Nan::GetCurrentContext())).ToLocalChecked());
-  exports->Set(Nan::New("AdminClient").ToLocalChecked(),
-    (tpl->GetFunction(Nan::GetCurrentContext())).ToLocalChecked());
+  Nan::Set(exports, Nan::New("AdminClient").ToLocalChecked(),
+    tpl->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
 }
 
 void AdminClient::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
@@ -546,9 +546,6 @@ NAN_METHOD(AdminClient::NodeCreatePartitions) {
   v8::Local<v8::Function> cb = info[3].As<v8::Function>();
   Nan::Callback *callback = new Nan::Callback(cb);
   AdminClient* client = ObjectWrap::Unwrap<AdminClient>(info.This());
-
-  // Get the timeout
-  int timeout = Nan::To<int32_t>(info[2]).FromJust();
 
   // Get the total number of desired partitions
   int partition_total_count = Nan::To<int32_t>(info[1]).FromJust();

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -64,24 +64,30 @@ void ConstantsInit(v8::Local<v8::Object> exports) {
   NODE_DEFINE_CONSTANT(topicConstants, RdKafka::Topic::OFFSET_STORED);
   NODE_DEFINE_CONSTANT(topicConstants, RdKafka::Topic::OFFSET_INVALID);
 
-  exports->Set(Nan::New("topic").ToLocalChecked(), topicConstants);
+  Nan::Set(exports, Nan::New("topic").ToLocalChecked(), topicConstants);
 
-  exports->Set(Nan::New("err2str").ToLocalChecked(),
+  Nan::Set(exports, Nan::New("err2str").ToLocalChecked(),
     Nan::GetFunction(Nan::New<v8::FunctionTemplate>(NodeRdKafkaErr2Str)).ToLocalChecked());  // NOLINT
 
-  exports->Set(Nan::New("features").ToLocalChecked(),
+  Nan::Set(exports, Nan::New("features").ToLocalChecked(),
     Nan::GetFunction(Nan::New<v8::FunctionTemplate>(NodeRdKafkaBuildInFeatures)).ToLocalChecked());  // NOLINT
 }
 
-void Init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
+void Init(v8::Local<v8::Object> exports, v8::Local<v8::Value> m_, void* v_) {
+#ifdef NODE_MAJOR_VERSION <= 8
   AtExit(RdKafkaCleanup);
+#else
+  v8::Local<v8::Context> context = Nan::GetCurrentContext();
+  node::Environment* env = node::GetCurrentEnvironment(context);
+  AtExit(env, RdKafkaCleanup, NULL);
+#endif
   KafkaConsumer::Init(exports);
   Producer::Init(exports);
   AdminClient::Init(exports);
   Topic::Init(exports);
   ConstantsInit(exports);
 
-  exports->Set(Nan::New("librdkafkaVersion").ToLocalChecked(),
+  Nan::Set(exports, Nan::New("librdkafkaVersion").ToLocalChecked(),
       Nan::New(RdKafka::version_str().c_str()).ToLocalChecked());
 }
 

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -42,7 +42,7 @@ v8::Local<v8::Array> TopicPartitionListToV8Array(
         Nan::New<v8::Number>(tp.offset));
     }
 
-    tp_array->Set(i, tp_obj);
+    Nan::Set(tp_array, i, tp_obj);
   }
 
   return tp_array;

--- a/src/errors.cc
+++ b/src/errors.cc
@@ -19,9 +19,9 @@ v8::Local<v8::Object> RdKafkaError(const RdKafka::ErrorCode &err, std::string er
 
   v8::Local<v8::Object> ret = Nan::New<v8::Object>();
 
-  ret->Set(Nan::New("message").ToLocalChecked(),
+  Nan::Set(ret, Nan::New("message").ToLocalChecked(),
     Nan::New<v8::String>(errstr).ToLocalChecked());
-  ret->Set(Nan::New("code").ToLocalChecked(),
+  Nan::Set(ret, Nan::New("code").ToLocalChecked(),
     Nan::New<v8::Number>(code));
 
   return ret;

--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -535,7 +535,7 @@ void KafkaConsumer::Init(v8::Local<v8::Object> exports) {
 
   constructor.Reset((tpl->GetFunction(Nan::GetCurrentContext()))
     .ToLocalChecked());
-  exports->Set(Nan::New("KafkaConsumer").ToLocalChecked(),
+  Nan::Set(exports, Nan::New("KafkaConsumer").ToLocalChecked(),
     (tpl->GetFunction(Nan::GetCurrentContext())).ToLocalChecked());
 }
 
@@ -712,8 +712,10 @@ NAN_METHOD(KafkaConsumer::NodeAssign) {
   std::vector<RdKafka::TopicPartition*> topic_partitions;
 
   for (unsigned int i = 0; i < partitions->Length(); ++i) {
-    v8::Local<v8::Value> partition_obj_value = partitions->Get(i);
-    if (!partition_obj_value->IsObject()) {
+    v8::Local<v8::Value> partition_obj_value;
+    if (!(
+          Nan::Get(partitions, i).ToLocal(&partition_obj_value) &&
+          partition_obj_value->IsObject())) {
       Nan::ThrowError("Must pass topic-partition objects");
     }
 

--- a/src/producer.cc
+++ b/src/producer.cc
@@ -90,8 +90,8 @@ void Producer::Init(v8::Local<v8::Object> exports) {
   constructor.Reset((tpl->GetFunction(Nan::GetCurrentContext()))
     .ToLocalChecked());
 
-  exports->Set(Nan::New("Producer").ToLocalChecked(),
-    (tpl->GetFunction(Nan::GetCurrentContext())).ToLocalChecked());
+  Nan::Set(exports, Nan::New("Producer").ToLocalChecked(),
+    tpl->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
 }
 
 void Producer::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
@@ -450,17 +450,18 @@ NAN_METHOD(Producer::NodeProduce) {
 
     if (v8Headers->Length() >= 1) {
       for (unsigned int i = 0; i < v8Headers->Length(); i++) {
-        v8::Local<v8::Object> header = v8Headers->Get(i)->ToObject(
-          Nan::GetCurrentContext()).ToLocalChecked();
+        v8::Local<v8::Object> header = Nan::Get(v8Headers, i).ToLocalChecked()
+          ->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
         if (header.IsEmpty()) {
           continue;
         }
 
         v8::Local<v8::Array> props = header->GetOwnPropertyNames(
           Nan::GetCurrentContext()).ToLocalChecked();
-        Nan::MaybeLocal<v8::String> v8Key = Nan::To<v8::String>(props->Get(0));
-        Nan::MaybeLocal<v8::String> v8Value =
-          Nan::To<v8::String>(header->Get(v8Key.ToLocalChecked()));
+        Nan::MaybeLocal<v8::String> v8Key = Nan::To<v8::String>(
+            Nan::Get(props, 0).ToLocalChecked());
+        Nan::MaybeLocal<v8::String> v8Value = Nan::To<v8::String>(
+            Nan::Get(header, v8Key.ToLocalChecked()).ToLocalChecked());
 
         Nan::Utf8String uKey(v8Key.ToLocalChecked());
         std::string key(*uKey);

--- a/src/topic.cc
+++ b/src/topic.cc
@@ -89,8 +89,8 @@ void Topic::Init(v8::Local<v8::Object> exports) {
   constructor.Reset((tpl->GetFunction(Nan::GetCurrentContext()))
     .ToLocalChecked());
 
-  exports->Set(Nan::New("Topic").ToLocalChecked(),
-    (tpl->GetFunction(Nan::GetCurrentContext())).ToLocalChecked());
+  Nan::Set(exports, Nan::New("Topic").ToLocalChecked(),
+    tpl->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
 }
 
 void Topic::New(const Nan::FunctionCallbackInfo<v8::Value>& info) {

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -569,7 +569,7 @@ void KafkaConsumerConsumeNum::HandleOKCallback() {
         it != m_messages.end(); ++it) {
       i++;
       RdKafka::Message* message = *it;
-      returnArray->Set(i, Conversion::Message::ToV8Object(message));
+      Nan::Set(returnArray, i, Conversion::Message::ToV8Object(message));
 
       delete message;
     }


### PR DESCRIPTION
Builds and passes tests on Ubuntu with 13.x.                                     
                                                                                 
Also fixes many deprecations.  A few outstanding deprecations related to         
integrating with the new async context tracking API remain, so                   
continuation-local-storage may (still) not work (have not checked).              
                                                                                 
Fixes: https://github.com/Blizzard/node-rdkafka/issues/733 

-----

This was a fairly mechanical fix, I'm not that familiar with the code or usage.

I noticed that `npm test` is passing but `make`  is not, which concerned me, but it turns out the same is true for master. So, I'm still concerned :-), but it isn't a problem intoduced by this PR AFAICT.