### PR TITLE
Update dev dep: node-gyp to v5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jsdoc": "^3.4.0",
     "jshint": "^2.10.1",
     "mocha": "^5.2.0",
-    "node-gyp": "3.x",
+    "node-gyp": "^5.1.0",
     "toolkit-jsdoc": "^1.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Note that this is _not_ necessary for package _users_. Its a dev
dependency, but v5.x is the version that comes with current npm
releases, I suggest this package should track that. Note that 3.x is
quite old, and misses numerous bug fixes, so isn't going to work on lots
of systems, particularly Python 3 systems.