### PR TITLE
Drop support for EOL Node.js versions (breaking)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ cache:
   directories:
   - node_modules
 node_js:
-  - "4"
-  - "6"
-  - "8"
   - "10"
   - "12"
   - "13"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Play nice; Play fair.
 ## Requirements
 
 * Apache Kafka >=0.9
-* Node.js >=4
+* Node.js >=10
 * Linux/Mac
 * Windows?! See below
 * OpenSSL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-rdkafka",
-  "version": "v2.8.1",
+  "version": "v3.0.0",
   "description": "Node.js bindings for librdkafka",
   "librdkafka": "1.3.0",
   "main": "lib/index.js",
@@ -43,6 +43,6 @@
     "nan": "^2.14.0"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   }
 }


### PR DESCRIPTION
Sync opinion on supported version between README, package.json, and
.travis.yml (was 4 or 6, depending), and drop support for EOL Node.js
versions.

See: https://github.com/nodejs/Release/#end-of-life-releases