### PR TITLE
Update required OpenSSL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Play nice; Play fair.
 * Node.js >=4
 * Linux/Mac
 * Windows?! See below
-* openssl 1.0.2
+* OpenSSL
 
 ### Mac OS High Sierra / Mojave
 


### PR DESCRIPTION
OpenSSL 1.0.2 is EOL, as is 1.1.0. Node.js 10.x and later use OpenSSL
1.1.1. Distros might choose to compile and link their custom builds of
10.x against 1.1.0, but 12.x and later don't support older than 1.1.1.

Also, given that Node.js exports the OpenSSL symbols to bindings, it
would be unwise for a binding to use a version of OpenSSL _other_ than
that used by the Node.js the binding is built against.

All of which is to say... its hard to specify exactly what version of
OpenSSL should be used, but it definitely is no longer 1.0.2.