### PR TITLE
Update readme to warn users of an specific installation problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ export CPPFLAGS=-I/usr/local/opt/openssl/include
 export LDFLAGS=-L/usr/local/opt/openssl/lib
 ```
 
+Also make sure that your path does not contain any whitespace character. For example, if your directory is called "my project", then rename it to something like "my-project".
+
 Then you can run `npm install` on your application to get it to build correctly.
 
 __NOTE:__ From the `librdkafka` docs


### PR DESCRIPTION
There is a problem where some installation step cannot read the path correctly if any directory has a whitespace in its name:

![image](https://user-images.githubusercontent.com/14261943/76973253-744ec780-690e-11ea-96ca-f15b0b09f335.png)

I know this is not a fix, but I honestly don't have much time to dive into the problem right now, so I thought I could at least help some way.