### PR TITLE
InternalAdminClient should contain connect()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -212,6 +212,7 @@ declare interface InternalAdminClient {
     createPartitions(topic: String, desiredPartitions: number, cb?: (err: any, data: any) => any): void;
     createPartitions(topic: String, desiredPartitions: number, timeout?: number, cb?: (err: any, data: any) => any): void;
 
+    connect(): void;
     disconnect(): void;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-rdkafka",
-  "version": "v2.7.4",
+  "version": "2.7.5",
   "description": "Node.js bindings for librdkafka",
   "librdkafka": "1.3.0",
   "main": "lib/index.js",


### PR DESCRIPTION
When using typescipt the connect() method on the AdminClient is not accessible since it is not included on the interface. However, it is included in the implementation as shown in https://github.com/Blizzard/node-rdkafka/blob/master/lib/admin.js#L92.