### PR TITLE
When the consumer read timeout, try to read after the value of `timeout`

### DIFF
--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -17,7 +17,7 @@ var KafkaConsumerStream = require('./kafka-consumer-stream');
 var LibrdKafkaError = require('./error');
 var TopicPartition = require('./topic-partition');
 var shallowCopy = require('./util').shallowCopy;
-var DEFAULT_RETRY_READ_INTERVAL = 500;
+var DEFAULT_CONSUME_LOOP_TIMEOUT_DELAY = 500;
 var DEFAULT_CONSUME_TIME_OUT = 1000;
 util.inherits(KafkaConsumer, Client);
 
@@ -125,8 +125,8 @@ function KafkaConsumer(conf, topicConf) {
   this.globalConfig = conf;
   this.topicConfig = topicConf;
 
-  this._consumeTimeout = DEFAULT_CONSUME_TIME_OUT;
-  this._retryReadInterval = DEFAULT_RETRY_READ_INTERVAL;
+  this._consumeTimeout = DEFAULT_CONSUME_LOOP_TIMEOUT_DELAY;
+  this._consumeLoopTimeoutDelay = DEFAULT_CONSUME_LOOP_TIMEOUT_DELAY;
 }
 
 /**
@@ -134,15 +134,15 @@ function KafkaConsumer(conf, topicConf) {
  * @param {number} timeoutMs - number of milliseconds to wait for a message to be fetched
  */
 KafkaConsumer.prototype.setDefaultConsumeTimeout = function(timeoutMs) {
-  this._consumeTimeout = Number(timeoutMs) || DEFAULT_CONSUME_TIME_OUT;
+  this._consumeTimeout = timeoutMs;
 };
 
 /**
- * Set the default value of waiting for the next time to read when current reading get none data.
- * @param {number} intervalMs - number of milliseconds to sleep before the next reading
+ * Set the default sleep delay for the next consume loop after the previous one has timed out.
+ * @param {number} intervalMs - number of milliseconds to sleep after a message fetch has timed out
  */
-KafkaConsumer.prototype.setDefaultRetryReadInterval = function(intervalMs) {
-  this._retryReadInterval = Number(intervalMs) || DEFAULT_RETRY_READ_INTERVAL;
+KafkaConsumer.prototype.setDefaultConsumeLoopTimeoutDelay = function(intervalMs) {
+  this._consumeLoopTimeoutDelay = intervalMs;
 };
 
 /**
@@ -379,7 +379,7 @@ KafkaConsumer.prototype.unsubscribe = function() {
  * is fetched.
  */
 KafkaConsumer.prototype.consume = function(number, cb) {
-  var timeoutMs = this._consumeTimeout || DEFAULT_CONSUME_TIME_OUT;
+  var timeoutMs = this._consumeTimeout || DEFAULT_CONSUME_LOOP_TIMEOUT_DELAY;
   var self = this;
 
   if ((number && typeof number === 'number') || (number && cb)) {
@@ -419,7 +419,7 @@ KafkaConsumer.prototype.consume = function(number, cb) {
  */
 KafkaConsumer.prototype._consumeLoop = function(timeoutMs, cb) {
   var self = this;
-  var retryReadInterval = this._retryReadInterval;
+  var retryReadInterval = this._consumeLoopTimeoutDelay;
   self._client.consumeLoop(timeoutMs, retryReadInterval, function readCallback(err, message) {
 
     if (err) {

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -17,7 +17,8 @@ var KafkaConsumerStream = require('./kafka-consumer-stream');
 var LibrdKafkaError = require('./error');
 var TopicPartition = require('./topic-partition');
 var shallowCopy = require('./util').shallowCopy;
-
+var DEFAULT_RETRY_READ_INTERVAL = 500;
+var DEFAULT_CONSUME_TIME_OUT = 1000;
 util.inherits(KafkaConsumer, Client);
 
 /**
@@ -124,7 +125,8 @@ function KafkaConsumer(conf, topicConf) {
   this.globalConfig = conf;
   this.topicConfig = topicConf;
 
-  this._consumeTimeout = 1000;
+  this._consumeTimeout = DEFAULT_CONSUME_TIME_OUT;
+  this._retryReadInterval = DEFAULT_RETRY_READ_INTERVAL;
 }
 
 /**
@@ -132,7 +134,15 @@ function KafkaConsumer(conf, topicConf) {
  * @param {number} timeoutMs - number of milliseconds to wait for a message to be fetched
  */
 KafkaConsumer.prototype.setDefaultConsumeTimeout = function(timeoutMs) {
-  this._consumeTimeout = timeoutMs;
+  this._consumeTimeout = Number(timeoutMs) || DEFAULT_CONSUME_TIME_OUT;
+};
+
+/**
+ * Set the default value of waiting for the next time to read when current reading get none data.
+ * @param {number} intervalMs - number of milliseconds to sleep before the next reading
+ */
+KafkaConsumer.prototype.setDefaultRetryReadInterval = function(intervalMs) {
+  this._retryReadInterval = Number(intervalMs) || DEFAULT_RETRY_READ_INTERVAL;
 };
 
 /**
@@ -369,7 +379,7 @@ KafkaConsumer.prototype.unsubscribe = function() {
  * is fetched.
  */
 KafkaConsumer.prototype.consume = function(number, cb) {
-  var timeoutMs = this._consumeTimeout || 1000;
+  var timeoutMs = this._consumeTimeout || DEFAULT_CONSUME_TIME_OUT;
   var self = this;
 
   if ((number && typeof number === 'number') || (number && cb)) {
@@ -409,8 +419,8 @@ KafkaConsumer.prototype.consume = function(number, cb) {
  */
 KafkaConsumer.prototype._consumeLoop = function(timeoutMs, cb) {
   var self = this;
-
-  self._client.consumeLoop(timeoutMs, function readCallback(err, message) {
+  var retryReadInterval = this._retryReadInterval;
+  self._client.consumeLoop(timeoutMs, retryReadInterval, function readCallback(err, message) {
 
     if (err) {
       // A few different types of errors here

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -125,7 +125,7 @@ function KafkaConsumer(conf, topicConf) {
   this.globalConfig = conf;
   this.topicConfig = topicConf;
 
-  this._consumeTimeout = DEFAULT_CONSUME_LOOP_TIMEOUT_DELAY;
+  this._consumeTimeout = DEFAULT_CONSUME_TIME_OUT;
   this._consumeLoopTimeoutDelay = DEFAULT_CONSUME_LOOP_TIMEOUT_DELAY;
 }
 
@@ -379,7 +379,7 @@ KafkaConsumer.prototype.unsubscribe = function() {
  * is fetched.
  */
 KafkaConsumer.prototype.consume = function(number, cb) {
-  var timeoutMs = this._consumeTimeout || DEFAULT_CONSUME_LOOP_TIMEOUT_DELAY;
+  var timeoutMs = this._consumeTimeout || DEFAULT_CONSUME_TIME_OUT;
   var self = this;
 
   if ((number && typeof number === 'number') || (number && cb)) {

--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -1044,16 +1044,16 @@ NAN_METHOD(KafkaConsumer::NodeResume) {
 NAN_METHOD(KafkaConsumer::NodeConsumeLoop) {
   Nan::HandleScope scope;
 
-  if (info.Length() < 2) {
+  if (info.Length() < 3) {
     // Just throw an exception
     return Nan::ThrowError("Invalid number of parameters");
   }
 
-  if (!info[0]->IsNumber()) {
-    return Nan::ThrowError("Need to specify a timeout");
+  if (!info[1]->IsNumber()) {
+    return Nan::ThrowError("Need to specify a sleep delay");
   }
 
-  if (!info[1]->IsFunction()) {
+  if (!info[2]->IsFunction()) {
     return Nan::ThrowError("Need to specify a callback");
   }
 

--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -1049,6 +1049,10 @@ NAN_METHOD(KafkaConsumer::NodeConsumeLoop) {
     return Nan::ThrowError("Invalid number of parameters");
   }
 
+  if (!info[0]->IsNumber()) {
+    return Nan::ThrowError("Need to specify a timeout");
+  }
+
   if (!info[1]->IsNumber()) {
     return Nan::ThrowError("Need to specify a sleep delay");
   }

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -421,11 +421,11 @@ void KafkaConsumerDisconnect::HandleErrorCallback() {
 KafkaConsumerConsumeLoop::KafkaConsumerConsumeLoop(Nan::Callback *callback,
                                      KafkaConsumer* consumer,
                                      const int & timeout_ms,
-                                     const int & retry_interval_ms) :
+                                     const int & timeout_sleep_delay_ms) :
   MessageWorker(callback),
   consumer(consumer),
   m_timeout_ms(timeout_ms),
-  m_retry_read_ms(retry_interval_ms),
+  m_timeout_sleep_delay_ms(timeout_sleep_delay_ms),
   m_rand_seed(time(NULL)) {}
 
 KafkaConsumerConsumeLoop::~KafkaConsumerConsumeLoop() {}
@@ -454,9 +454,9 @@ void KafkaConsumerConsumeLoop::Execute(const ExecutionMessageBus& bus) {
         // new messages fetched quickly enough. This isn't really
         // an error that should kill us.
         #ifndef _WIN32
-        usleep(m_retry_read_ms*1000);
+        usleep(m_timeout_sleep_delay_ms*1000);
         #else
-        _sleep(m_retry_read_ms);
+        _sleep(m_timeout_sleep_delay_ms);
         #endif
         break;
       case RdKafka::ERR_NO_ERROR:

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -452,9 +452,9 @@ void KafkaConsumerConsumeLoop::Execute(const ExecutionMessageBus& bus) {
         // new messages fetched quickly enough. This isn't really
         // an error that should kill us.
         #ifndef _WIN32
-        usleep(500*1000);
+        usleep(m_timeout_ms*1000);
         #else
-        _sleep(500);
+        _sleep(m_timeout_ms);
         #endif
         break;
       case RdKafka::ERR_NO_ERROR:

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -420,10 +420,12 @@ void KafkaConsumerDisconnect::HandleErrorCallback() {
 
 KafkaConsumerConsumeLoop::KafkaConsumerConsumeLoop(Nan::Callback *callback,
                                      KafkaConsumer* consumer,
-                                     const int & timeout_ms) :
+                                     const int & timeout_ms,
+                                     const int & retry_interval_ms) :
   MessageWorker(callback),
   consumer(consumer),
   m_timeout_ms(timeout_ms),
+  m_retry_read_ms(retry_interval_ms),
   m_rand_seed(time(NULL)) {}
 
 KafkaConsumerConsumeLoop::~KafkaConsumerConsumeLoop() {}
@@ -452,9 +454,9 @@ void KafkaConsumerConsumeLoop::Execute(const ExecutionMessageBus& bus) {
         // new messages fetched quickly enough. This isn't really
         // an error that should kill us.
         #ifndef _WIN32
-        usleep(m_timeout_ms*1000);
+        usleep(m_retry_read_ms*1000);
         #else
-        _sleep(m_timeout_ms);
+        _sleep(m_retry_read_ms);
         #endif
         break;
       case RdKafka::ERR_NO_ERROR:

--- a/src/workers.h
+++ b/src/workers.h
@@ -277,7 +277,7 @@ class KafkaConsumerDisconnect : public ErrorAwareWorker {
 class KafkaConsumerConsumeLoop : public MessageWorker {
  public:
   KafkaConsumerConsumeLoop(Nan::Callback*,
-    NodeKafka::KafkaConsumer*, const int &);
+    NodeKafka::KafkaConsumer*, const int &, const int &);
   ~KafkaConsumerConsumeLoop();
 
   void Execute(const ExecutionMessageBus&);
@@ -288,6 +288,7 @@ class KafkaConsumerConsumeLoop : public MessageWorker {
   NodeKafka::KafkaConsumer * consumer;
   const int m_timeout_ms;
   unsigned int m_rand_seed;
+  const int m_retry_read_ms;
 };
 
 class KafkaConsumerConsume : public ErrorAwareWorker {

--- a/src/workers.h
+++ b/src/workers.h
@@ -288,7 +288,7 @@ class KafkaConsumerConsumeLoop : public MessageWorker {
   NodeKafka::KafkaConsumer * consumer;
   const int m_timeout_ms;
   unsigned int m_rand_seed;
-  const int m_retry_read_ms;
+  const int m_timeout_sleep_delay_ms;
 };
 
 class KafkaConsumerConsume : public ErrorAwareWorker {


### PR DESCRIPTION
The pull request is aimed to resolve the issue of https://github.com/Blizzard/node-rdkafka/issues/709 .