### PR TITLE
Expose ConsumerStream and ProducerStream interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -123,13 +123,13 @@ export interface WriteStreamOptions extends WritableOptions {
     connectOptions?: any;
 }
 
-interface ProducerStream extends Writable {
+export interface ProducerStream extends Writable {
     producer: Producer;
     connect(metadataOptions?: MetadataOptions): void;
     close(cb?: () => void): void;
 }
 
-interface ConsumerStream extends Readable {
+export interface ConsumerStream extends Readable {
     consumer: KafkaConsumer;
     connect(options: ConsumerGlobalConfig): void;
     close(cb?: () => void): void;


### PR DESCRIPTION
I have a consumer/producer that is implemented on top of these `ConsumerStream` and `ProducerStream` and before this commit (https://github.com/Blizzard/node-rdkafka/commit/66d53834e33c8cb1cfdc1d2d31b5eae851b3841a) they were both being exported.
  
It would be nice to have typings for this interface and not have to use `any`.