### PR TITLE
Fix C preprocessor syntax error affecting node 8.x

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -74,7 +74,7 @@ void ConstantsInit(v8::Local<v8::Object> exports) {
 }
 
 void Init(v8::Local<v8::Object> exports, v8::Local<v8::Value> m_, void* v_) {
-#ifdef NODE_MAJOR_VERSION <= 8
+#if NODE_MAJOR_VERSION <= 8
   AtExit(RdKafkaCleanup);
 #else
   v8::Local<v8::Context> context = Nan::GetCurrentContext();


### PR DESCRIPTION
22452f83 introduced bad syntax

	  #ifdef NODE_MAJOR_VERSION <= 8

That's not valid, I'm not sure why I didn't notice the compiler warning,
but this fixes it. Its possible that nobody tried to use node-rdkafka
with Node.js <= 8.x yet.