### PR TITLE
maybeDone missing argument added

### DIFF
--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -105,12 +105,12 @@ describe('Consumer/Producer', function() {
       }
     }
 
-    consumer.disconnect(function() {
-      maybeDone();
+    consumer.disconnect(function(err) {
+      maybeDone(err);
     });
 
-    producer.disconnect(function() {
-      maybeDone();
+    producer.disconnect(function(err) {
+      maybeDone(err);
     });
   });
 


### PR DESCRIPTION
In the afterEach part maybeDone is defined to take 1 `err` argument but it is called with 0.