### PR TITLE
fix: wrap offset.commit errors with LibrdKafkaError

### DIFF
--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -92,11 +92,13 @@ function KafkaConsumer(conf, topicConf) {
 
   if (onOffsetCommit && typeof onOffsetCommit === 'boolean') {
     conf.offset_commit_cb = function(err, offsets) {
+      err = LibrdKafkaError.create(err);
       // Emit the event
       self.emit('offset.commit', err, offsets);
     };
   } else if (onOffsetCommit && typeof onOffsetCommit === 'function') {
     conf.offset_commit_cb = function(err, offsets) {
+      err = LibrdKafkaError.create(err);
       // Emit the event
       self.emit('offset.commit', err, offsets);
       onOffsetCommit.call(self, err, offsets);

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -92,13 +92,17 @@ function KafkaConsumer(conf, topicConf) {
 
   if (onOffsetCommit && typeof onOffsetCommit === 'boolean') {
     conf.offset_commit_cb = function(err, offsets) {
-      err = LibrdKafkaError.create(err);
+      if (err) {
+        err = LibrdKafkaError.create(err);
+      }
       // Emit the event
       self.emit('offset.commit', err, offsets);
     };
   } else if (onOffsetCommit && typeof onOffsetCommit === 'function') {
     conf.offset_commit_cb = function(err, offsets) {
-      err = LibrdKafkaError.create(err);
+      if (err) {
+        err = LibrdKafkaError.create(err);
+      }
       // Emit the event
       self.emit('offset.commit', err, offsets);
       onOffsetCommit.call(self, err, offsets);


### PR DESCRIPTION
These errors weren't properly being wrapped as `LibrdKafkaError`s, and were thus being emitted as [raw error codes](https://github.com/jpdstan/node-rdkafka/blob/c63ef5cd9f5983d572b1d959018d7b2e1ffd34aa/src/callbacks.h#L248) instead of error objects, as we expect in every other error callback on kafka events.