### PR TITLE
Fix producer/consumer memory leaks #731

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -53,32 +53,39 @@ function Client(globalConf, SubClientType, topicConf) {
 
   this._client = new SubClientType(globalConf, topicConf);
 
-  // primitive callbacks from c++ wrapper
-  // need binds on them if we want to broadcast the event via the emitter
+  var extractFunctions = function(obj) {
+    obj = obj || {};
+    var obj2 = {};
+    for (var p in obj) {
+      if (typeof obj[p] === "function") {
+        obj2[p] = obj[p];
+      }
+    }
+    return obj2;
+  }
+  this._cb_configs = {
+    global: extractFunctions(globalConf),
+    topic: extractFunctions(topicConf),
+    event: {},
+  }
 
-  // However, the C++ wrapper lazy processes callbacks.
-  // If we want to improve performance, removing this line is a good way to do it.
-  // we need to do this on creation of the object
-  // thats why we did some processing on config
-
-  // Self required because we are inside an async callback function scope
   if (!no_event_cb) {
-    this._client.onEvent(function eventHandler(eventType, eventData) {
+    this._cb_configs.event.event_cb = function(eventType, eventData) {
       switch (eventType) {
         case 'error':
-          self.emit('event.error', LibrdKafkaError.create(eventData));
+          this.emit('event.error', LibrdKafkaError.create(eventData));
           break;
         case 'stats':
-          self.emit('event.stats', eventData);
+          this.emit('event.stats', eventData);
           break;
         case 'log':
-          self.emit('event.log', eventData);
+          this.emit('event.log', eventData);
           break;
         default:
-          self.emit('event.event', eventData);
-          self.emit('event.' + eventType, eventData);
+          this.emit('event.event', eventData);
+          this.emit('event.' + eventType, eventData);
       }
-    });
+    }.bind(this);
   }
 
   this.metrics = {};
@@ -182,6 +189,8 @@ Client.prototype.connect = function(metadataOptions, cb) {
     }
   };
 
+  this._client.configureCallbacks(true, this._cb_configs);
+
   this._client.connect(function(err, info) {
     if (err) {
       fail(LibrdKafkaError.create(err)); return;
@@ -284,6 +293,7 @@ Client.prototype.disconnect = function(cb) {
     this._client.disconnect(function() {
       // this take 5000 milliseconds. Librdkafka needs to make sure the memory
       // has been cleaned up before we delete things. @see RdKafka::wait_destroyed
+      self._client.configureCallbacks(false, self._cb_configs);
 
       // Broadcast metrics. Gives people one last chance to do something with them
       self._isDisconnecting = false;

--- a/lib/producer.js
+++ b/lib/producer.js
@@ -73,7 +73,6 @@ function Producer(conf, topicConf) {
   // client is an initialized consumer object
   // @see NodeKafka::Producer::Init
   Client.call(this, conf, Kafka.Producer, topicConf);
-  var self = this;
 
   // Delete these keys after saving them in vars
   this.globalConfig = conf;
@@ -86,15 +85,16 @@ function Producer(conf, topicConf) {
   this.pollInterval = undefined;
 
   if (dr_msg_cb || dr_cb) {
-    this._client.onDeliveryReport(function onDeliveryReport(err, report) {
+    this._cb_configs.event.delivery_cb =  function(err, report) {
       if (err) {
         err = LibrdKafkaError.create(err);
       }
-      self.emit('delivery-report', err, report);
-    }, !!dr_msg_cb);
+      this.emit('delivery-report', err, report);
+    }.bind(this);
+    this._cb_configs.event.delivery_cb.dr_msg_cb = !!dr_msg_cb;
 
     if (typeof dr_cb === 'function') {
-      self.on('delivery-report', dr_cb);
+      this.on('delivery-report', dr_cb);
     }
 
   }

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -256,12 +256,6 @@ size_t DeliveryReportDispatcher::Add(const DeliveryReport &e) {
   return events.size();
 }
 
-void DeliveryReportDispatcher::AddCallback(v8::Local<v8::Function> func) {
-  Nan::Persistent<v8::Function,
-                  Nan::CopyablePersistentTraits<v8::Function> > value(func);
-  callbacks.push_back(value);
-}
-
 void DeliveryReportDispatcher::Flush() {
   Nan::HandleScope scope;
 

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -104,11 +104,21 @@ void Dispatcher::Dispatch(const int _argc, Local<Value> _argv[]) {
   }
 }
 
-void Dispatcher::AddCallback(v8::Local<v8::Function> func) {
+void Dispatcher::AddCallback(const v8::Local<v8::Function> &cb) {
   Nan::Persistent<v8::Function,
-                  Nan::CopyablePersistentTraits<v8::Function> > value(func);
+                  Nan::CopyablePersistentTraits<v8::Function> > value(cb);
   // PersistentCopyableFunction value(func);
   callbacks.push_back(value);
+}
+
+void Dispatcher::RemoveCallback(const v8::Local<v8::Function> &cb) {
+  for (size_t i=0; i < callbacks.size(); i++) {
+    if (callbacks[i] == cb) {
+      callbacks[i].Reset();
+      callbacks.erase(callbacks.begin() + i);
+      break;
+    }
+  }
 }
 
 event_t::event_t(const RdKafka::Event &event) {
@@ -476,11 +486,6 @@ void RebalanceDispatcher::Flush() {
   }
 }
 
-Rebalance::Rebalance(v8::Local<v8::Function> &cb) {
-  dispatcher.AddCallback(cb);
-}
-Rebalance::~Rebalance() {}
-
 void Rebalance::rebalance_cb(RdKafka::KafkaConsumer *consumer,
     RdKafka::ErrorCode err, std::vector<RdKafka::TopicPartition*> &partitions) {
   dispatcher.Add(rebalance_event_t(err, partitions));
@@ -528,11 +533,6 @@ void OffsetCommitDispatcher::Flush() {
     Dispatch(argc, argv);
   }
 }
-
-OffsetCommit::OffsetCommit(v8::Local<v8::Function> &cb) {
-  dispatcher.AddCallback(cb);
-}
-OffsetCommit::~OffsetCommit() {}
 
 void OffsetCommit::offset_commit_cb(RdKafka::ErrorCode err,
     std::vector<RdKafka::TopicPartition*> &offsets) {

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -131,7 +131,6 @@ class DeliveryReportDispatcher : public Dispatcher {
   ~DeliveryReportDispatcher();
   void Flush();
   size_t Add(const DeliveryReport &);
-  void AddCallback(v8::Local<v8::Function>);
  protected:
   std::deque<DeliveryReport> events;
 };

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -33,7 +33,8 @@ class Dispatcher {
   Dispatcher();
   ~Dispatcher();
   void Dispatch(const int, v8::Local<v8::Value> []);
-  void AddCallback(v8::Local<v8::Function>);
+  void AddCallback(const v8::Local<v8::Function>&);
+  void RemoveCallback(const v8::Local<v8::Function>&);
   bool HasCallbacks();
   virtual void Flush() = 0;
   void Execute();
@@ -218,9 +219,6 @@ class RebalanceDispatcher : public Dispatcher {
 
 class Rebalance : public RdKafka::RebalanceCb {
  public:
-  explicit Rebalance(v8::Local<v8::Function>&);
-  ~Rebalance();
-
   void rebalance_cb(RdKafka::KafkaConsumer *, RdKafka::ErrorCode,
     std::vector<RdKafka::TopicPartition*> &);
 
@@ -241,9 +239,6 @@ class OffsetCommitDispatcher : public Dispatcher {
 
 class OffsetCommit : public RdKafka::OffsetCommitCb {
  public:
-  explicit OffsetCommit(v8::Local<v8::Function>&);
-  ~OffsetCommit();
-
   void offset_commit_cb(RdKafka::ErrorCode, std::vector<RdKafka::TopicPartition*> &);  // NOLINT
 
   OffsetCommitDispatcher dispatcher;

--- a/src/config.h
+++ b/src/config.h
@@ -31,6 +31,8 @@ class Conf : public RdKafka::Conf {
 
   void listen();
   void stop();
+
+  void ConfigureCallback(const std::string &string_key, const v8::Local<v8::Function> &cb, bool add, std::string &errstr);
  protected:
   NodeKafka::Callbacks::Rebalance * m_rebalance_cb = NULL;
   NodeKafka::Callbacks::OffsetCommit * m_offset_commit_cb = NULL;

--- a/src/connection.h
+++ b/src/connection.h
@@ -66,6 +66,8 @@ class Connection : public Nan::ObjectWrap {
   virtual void ActivateDispatchers() = 0;
   virtual void DeactivateDispatchers() = 0;
 
+  virtual void ConfigureCallback(const std::string &string_key, const v8::Local<v8::Function> &cb, bool add);
+
  protected:
   Connection(Conf*, Conf*);
   ~Connection();
@@ -84,7 +86,7 @@ class Connection : public Nan::ObjectWrap {
 
   RdKafka::Handle* m_client;
 
-  static NAN_METHOD(NodeOnEvent);
+  static NAN_METHOD(NodeConfigureCallbacks);
   static NAN_METHOD(NodeGetMetadata);
   static NAN_METHOD(NodeQueryWatermarkOffsets);
   static NAN_METHOD(NodeOffsetsForTimes);

--- a/src/kafka-consumer.cc
+++ b/src/kafka-consumer.cc
@@ -484,7 +484,7 @@ void KafkaConsumer::Init(v8::Local<v8::Object> exports) {
    * @sa NodeKafka::Connection
    */
 
-  Nan::SetPrototypeMethod(tpl, "onEvent", NodeOnEvent);
+  Nan::SetPrototypeMethod(tpl, "configureCallbacks", NodeConfigureCallbacks);
 
   /*
    * @brief Methods to do with establishing state
@@ -496,12 +496,6 @@ void KafkaConsumer::Init(v8::Local<v8::Object> exports) {
   Nan::SetPrototypeMethod(tpl, "queryWatermarkOffsets", NodeQueryWatermarkOffsets);  // NOLINT
   Nan::SetPrototypeMethod(tpl, "offsetsForTimes", NodeOffsetsForTimes);
   Nan::SetPrototypeMethod(tpl, "getWatermarkOffsets", NodeGetWatermarkOffsets);
-
-  /*
-   * Lifecycle events specifically designated for RdKafka::KafkaConsumer
-   *
-   * @sa RdKafka::KafkaConsumer
-   */
 
   /*
    * @brief Methods exposed to do with message retrieval

--- a/src/producer.h
+++ b/src/producer.h
@@ -80,6 +80,8 @@ class Producer : public Connection {
   void ActivateDispatchers();
   void DeactivateDispatchers();
 
+  void ConfigureCallback(const std::string &string_key, const v8::Local<v8::Function> &cb, bool add) override;
+
  protected:
   static Nan::Persistent<v8::Function> constructor;
   static void New(const Nan::FunctionCallbackInfo<v8::Value>&);
@@ -89,7 +91,6 @@ class Producer : public Connection {
 
  private:
   static NAN_METHOD(NodeProduce);
-  static NAN_METHOD(NodeOnDelivery);
   static NAN_METHOD(NodeSetPartitioner);
   static NAN_METHOD(NodeConnect);
   static NAN_METHOD(NodeDisconnect);

--- a/test/binding.spec.js
+++ b/test/binding.spec.js
@@ -56,7 +56,7 @@ module.exports = {
         });
       },
       'has necessary methods from superclass': function() {
-        var methods = ['connect', 'disconnect', 'onEvent', 'getMetadata'];
+        var methods = ['connect', 'disconnect', 'configureCallbacks', 'getMetadata'];
         methods.forEach(function(m) {
           t.equal(typeof(client[m]), 'function', 'Client is missing ' + m + ' method');
         });

--- a/test/consumer.spec.js
+++ b/test/consumer.spec.js
@@ -71,7 +71,7 @@ module.exports = {
       });
     },
     'has necessary methods from superclass': function() {
-      var methods = ['connect', 'disconnect', 'onEvent', 'getMetadata'];
+      var methods = ['connect', 'disconnect', 'configureCallbacks', 'getMetadata'];
       methods.forEach(function(m) {
         t.equal(typeof(client[m]), 'function', 'Client is missing ' + m + ' method');
       });


### PR DESCRIPTION
To dispatch internal events library persists their JavaScript callbacks in the underlying native code. These persistent callbacks disable garbage collection of their holding consumer or producer instance.

One approach to fix this issue is to implement some sort of `destroy()` method that would clean up those persistent callbacks but this doesn't feel natural in JavaScript.

A more natural approach is to wire up and persist those callbacks right before `connect()` call and to clean them up right after `disconnect()` call which is exactly what this PR is all about. This also enables instances re-usability so users can `connect` and `disconnect` as many times as they want and the instance will remain garbage collectible. Callbacks still have to be persisted but this time inside JavaScript (`_cb_configs` object). There are 3 types of those callbacks: global config callback, topic config callback, and producer/consumer specific callbacks.

One downside possibility is that certain events, like maybe `event.log`, could be triggered even before `connect` or after `disconnect`. In my tests this was not the case but again this still could be a possibility.

Ref #731 