### PR TITLE
#813 - Increase the line length to fix code style lint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ CONFIG_OUTPUTS = \
 CPPLINT_FILES = $(wildcard src/*.cc src/*.h)
 CPPLINT_FILTER = -legal/copyright
 JSLINT_FILES = lib/*.js test/*.js e2e/*.js
+CPPLINT_LINE_LENGTH=130
 
 PACKAGE = $(shell node -pe 'require("./package.json").name.split("/")[1]')
 VERSION = $(shell node -pe 'require("./package.json").version')
@@ -41,7 +42,7 @@ all: lint lib test e2e
 lint: cpplint jslint
 
 cpplint:
-	@$(PYTHON) $(CPPLINT) --filter=$(CPPLINT_FILTER) $(CPPLINT_FILES)
+	@$(PYTHON) $(CPPLINT) --linelength=$(CPPLINT_LINE_LENGTH) --filter=$(CPPLINT_FILTER) $(CPPLINT_FILES)
 
 jslint: node_modules/.dirstamp
 	@./node_modules/.bin/jshint --verbose $(JSLINT_FILES)


### PR DESCRIPTION
Fixes partially the issue https://github.com/Blizzard/node-rdkafka/issues/813.

**Environment Information**
 - OS: Mac 
 - Node Version: 12.16.3
 - NPM Version: 6.14.4
 - C++ Toolchain: g++
 - node-rdkafka version: master branch

**Steps to Reproduce**
`make lint`

**node-rdkafka Configuration Settings**

It is not relevant to this matter.

**Additional context**

```bash
Done processing src/admin.cc
src/binding.cc:77:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
Done processing src/binding.cc
Done processing src/callbacks.cc
Done processing src/common.cc
src/config.cc:101:  Lines should very rarely be longer than 100 characters  [whitespace/line_length] [4]
Done processing src/config.cc
src/connection.cc:218:  Lines should very rarely be longer than 100 characters  [whitespace/line_length] [4]
src/connection.cc:354:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
src/connection.cc:355:  Lines should very rarely be longer than 100 characters  [whitespace/line_length] [4]
src/connection.cc:360:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
src/connection.cc:361:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
src/connection.cc:380:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
src/connection.cc:381:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
Done processing src/connection.cc
Done processing src/errors.cc
Done processing src/kafka-consumer.cc
src/producer.cc:319:  Lines should very rarely be longer than 100 characters  [whitespace/line_length] [4]
src/producer.cc:323:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
src/producer.cc:408:  Lines should very rarely be longer than 100 characters  [whitespace/line_length] [4]
src/producer.cc:409:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
src/producer.cc:410:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
src/producer.cc:438:  Lines should very rarely be longer than 100 characters  [whitespace/line_length] [4]
Done processing src/producer.cc
Done processing src/topic.cc
Done processing src/workers.cc
Done processing src/admin.h
Done processing src/binding.h
Done processing src/callbacks.h
Done processing src/common.h
src/config.h:35:  Lines should very rarely be longer than 100 characters  [whitespace/line_length] [4]
src/config.h:35:  Is this a non-const reference? If so, make const or use a pointer: std::string &errstr  [runtime/references] [2]
Done processing src/config.h
src/connection.h:69:  Lines should very rarely be longer than 100 characters  [whitespace/line_length] [4]
Done processing src/connection.h
Done processing src/errors.h
Done processing src/kafka-consumer.h
src/producer.h:83:  Lines should very rarely be longer than 100 characters  [whitespace/line_length] [4]
Done processing src/producer.h
Done processing src/topic.h
Done processing src/workers.h
Total errors found: 19
make: *** [cpplint] Error 1
```


