### PR TITLE
Read the download url of librdkafka from Windows environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Windows build **is not** compiled from `librdkafka` source but it is rather link
 
 Requirements:
  * [node-gyp for Windows](https://github.com/nodejs/node-gyp#on-windows)  (the easies way to get it: `npm install --global --production windows-build-tools`.
- * The setting of environment variable of `DOWNLOAD_BASE_URL_LIB_RDKAFKA` is optional. If you set it, the builder will download the library of `librdkafka` from `${DOWNLOAD_BASE_URL_LIB_RDKAFKA}librdkafka.redist.${librdkafka-version-from-package.json}.nupkg`.
+ * The setting of environment variable of `BUILD_LIBRDKAFKA` is optional. If you set it, the builder will download the library of `librdkafka` from `${BUILD_LIBRDKAFKA}librdkafka.redist.${librdkafka-version-from-package.json}.nupkg`.
 
 **Note:** I _still_ do not recommend using `node-rdkafka` in production on Windows. This feature was in high demand and is provided to help develop, but we do not test against Windows, and windows support may lag behind Linux/Mac support because those platforms are the ones used to develop this library. Contributors are welcome if any Windows issues are found :)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Windows build **is not** compiled from `librdkafka` source but it is rather link
 
 Requirements:
  * [node-gyp for Windows](https://github.com/nodejs/node-gyp#on-windows)  (the easies way to get it: `npm install --global --production windows-build-tools`.
- * The setting of environment variable of `BUILD_LIBRDKAFKA` is optional. If you set it, the builder will download the library of `librdkafka` from `${BUILD_LIBRDKAFKA}librdkafka.redist.${librdkafka-version-from-package.json}.nupkg`.
 
 **Note:** I _still_ do not recommend using `node-rdkafka` in production on Windows. This feature was in high demand and is provided to help develop, but we do not test against Windows, and windows support may lag behind Linux/Mac support because those platforms are the ones used to develop this library. Contributors are welcome if any Windows issues are found :)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Using Alpine Linux? Check out the [docs](https://github.com/Blizzard/node-rdkafk
 Windows build **is not** compiled from `librdkafka` source but it is rather linked against appropriate version of static binary that gets downloaded from [librdkafka.redist NuGet package](https://www.nuget.org/packages/librdkafka.redist/) during installation.
 
 Requirements:
- * [node-gyp for Windows](https://github.com/nodejs/node-gyp#on-windows)  (the easies way to get it: `npm install --global --production windows-build-tools`, if your node version is 6.x or below, pleasse use `npm install --global --production windows-build-tools@3.1.0`)
+ * [node-gyp for Windows](https://github.com/nodejs/node-gyp#on-windows)  (the easies way to get it: `npm install --global --production windows-build-tools`.
+ * The setting of environment variable of `DOWNLOAD_BASE_URL_LIB_RDKAFKA` is optional. If you set it, the builder will download the library of `librdkafka` from `${DOWNLOAD_BASE_URL_LIB_RDKAFKA}librdkafka.redist.${librdkafka-version-from-package.json}.nupkg`.
 
 **Note:** I _still_ do not recommend using `node-rdkafka` in production on Windows. This feature was in high demand and is provided to help develop, but we do not test against Windows, and windows support may lag behind Linux/Mac support because those platforms are the ones used to develop this library. Contributors are welcome if any Windows issues are found :)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Using Alpine Linux? Check out the [docs](https://github.com/Blizzard/node-rdkafk
 Windows build **is not** compiled from `librdkafka` source but it is rather linked against appropriate version of static binary that gets downloaded from [librdkafka.redist NuGet package](https://www.nuget.org/packages/librdkafka.redist/) during installation.
 
 Requirements:
- * [node-gyp for Windows](https://github.com/nodejs/node-gyp#on-windows)  (the easies way to get it: `npm install --global --production windows-build-tools`.
+ * [node-gyp for Windows](https://github.com/nodejs/node-gyp#on-windows)  (the easies way to get it: `npm install --global --production windows-build-tools`, if your node version is 6.x or below, pleasse use `npm install --global --production windows-build-tools@3.1.0`)
 
 **Note:** I _still_ do not recommend using `node-rdkafka` in production on Windows. This feature was in high demand and is provided to help develop, but we do not test against Windows, and windows support may lag behind Linux/Mac support because those platforms are the ones used to develop this library. Contributors are welcome if any Windows issues are found :)
 

--- a/deps/windows-install.py
+++ b/deps/windows-install.py
@@ -12,7 +12,7 @@ buildReleaseDir = 'Release'
 
 # alternative: 'https://api.nuget.org/v3-flatcontainer/librdkafka.redist/{}/librdkafka.redist.{}.nupkg'.format(librdkafkaVersion, librdkafkaVersion)
 env_dist = os.environ
-downloadBaseUrl = env_dist['DOWNLOAD_BASE_URL_LIB_RDKAFKA'] if 'DOWNLOAD_BASE_URL_LIB_RDKAFKA' in env_dist else 'https://globalcdn.nuget.org/packages/'
+downloadBaseUrl = env_dist['BUILD_LIBRDKAFKA'] if 'BUILD_LIBRDKAFKA' in env_dist else 'https://globalcdn.nuget.org/packages/'
 librdkafkaNugetUrl = downloadBaseUrl + 'librdkafka.redist.{}.nupkg'.format(librdkafkaVersion)
 print 'download librdkafka form ' + librdkafkaNugetUrl
 outputDir = 'librdkafka.redist'

--- a/deps/windows-install.py
+++ b/deps/windows-install.py
@@ -1,6 +1,7 @@
 librdkafkaVersion = ''
 # read librdkafka version from package.json
 import json
+import os
 with open('../package.json') as f:
     librdkafkaVersion = json.load(f)['librdkafka']
 librdkafkaWinSufix = '7' if librdkafkaVersion == '0.11.5' else '';
@@ -10,7 +11,10 @@ depsIncludeDir = '../deps/include'
 buildReleaseDir = 'Release'
 
 # alternative: 'https://api.nuget.org/v3-flatcontainer/librdkafka.redist/{}/librdkafka.redist.{}.nupkg'.format(librdkafkaVersion, librdkafkaVersion)
-librdkafkaNugetUrl = 'https://www.nuget.org/api/v2/package/librdkafka.redist/{}'.format(librdkafkaVersion)
+env_dist = os.environ
+downloadBaseUrl = env_dist['DOWNLOAD_BASE_URL_LIB_RDKAFKA'] if 'DOWNLOAD_BASE_URL_LIB_RDKAFKA' in env_dist else 'https://globalcdn.nuget.org/packages/'
+librdkafkaNugetUrl = downloadBaseUrl + 'librdkafka.redist.{}.nupkg'.format(librdkafkaVersion)
+print 'download librdkafka form ' + librdkafkaNugetUrl
 outputDir = 'librdkafka.redist'
 outputFile = outputDir + '.zip'
 dllPath = outputDir + '/runtimes/win{}-x64/native'.format(librdkafkaWinSufix)

--- a/deps/windows-install.py
+++ b/deps/windows-install.py
@@ -12,7 +12,7 @@ buildReleaseDir = 'Release'
 
 # alternative: 'https://api.nuget.org/v3-flatcontainer/librdkafka.redist/{}/librdkafka.redist.{}.nupkg'.format(librdkafkaVersion, librdkafkaVersion)
 env_dist = os.environ
-downloadBaseUrl = env_dist['BUILD_LIBRDKAFKA'] if 'BUILD_LIBRDKAFKA' in env_dist else 'https://globalcdn.nuget.org/packages/'
+downloadBaseUrl = env_dist['NODE_RDKAFKA_NUGET_BASE_URL'] if 'NODE_RDKAFKA_NUGET_BASE_URL' in env_dist else 'https://globalcdn.nuget.org/packages/'
 librdkafkaNugetUrl = downloadBaseUrl + 'librdkafka.redist.{}.nupkg'.format(librdkafkaVersion)
 print 'download librdkafka form ' + librdkafkaNugetUrl
 outputDir = 'librdkafka.redist'


### PR DESCRIPTION
In Windows ,the download of the library of librdkafka may be so slowly, especially when you are in China. It may cost a long time to  download it. Sometime I have to wait for several hours. 
So I add an feature of reading the download url from environment variable.