### PR TITLE
Improve 'should return ready messages on partition EOF' e2e test

### DIFF
--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -190,10 +190,13 @@ describe('Consumer/Producer', function() {
       var consumeNone = function() {
         // With no new messages, the consume should wait whole timeout
         var start = Date.now();
-        consumer.setDefaultConsumeTimeout(1000);
+        // Set the timeout to 2000ms to see that it actually waits the whole time
+        // (Needs to be higher than fetch.max.wait.ms which is 1000 here
+        // to ensure we don't only wait that long)
+        consumer.setDefaultConsumeTimeout(2000);
         consumer.consume(100000, function(err, messages) {
           t.ifError(err);
-          t.ok(Date.now() - start >= 998);
+          t.ok(Date.now() - start >= 1998);
           t.equal(messages.length, 0);
 
           // Produce one message to cause EOF with waiting message when consuming all


### PR DESCRIPTION
Found while working on #803 and wondering why a regression I put there didn't lead to this test failing.
The regression I put there was removing the `if` condition in https://github.com/Blizzard/node-rdkafka/blob/master/src/workers.cc#L537-L539. Then I expected `consume` to directly return, but of cause it still waits for `fetch.max.wait.ms` as we only get EOF notifications at the end of the `fetch` call. Took me some time to figure that out 😂 .

Note that the heuristic of terminating the loop when seeing an `EOF` message is anyway not the best heuristic, really we should wait until we've seen `EOF` messages from _all_ partitions that are consumed, only in cases where we're only assigned to one partition is this the same. But this is beyond this PR.