### PR TITLE
Statically link librdkafka

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,7 @@
     # may be redefined in command line on configuration stage
     # "BUILD_LIBRDKAFKA%": "<!(echo ${BUILD_LIBRDKAFKA:-1})"
     "BUILD_LIBRDKAFKA%": "<!(node ./util/get-env.js BUILD_LIBRDKAFKA 1)",
+    "SASL": "<!(test -f /usr/include/sasl/sasl.h && echo y || echo n)"
   },
   "targets": [
     {
@@ -88,10 +89,22 @@
                       'OS=="linux"',
                       {
                         "libraries": [
-                          "../build/deps/librdkafka.so",
-                          "../build/deps/librdkafka++.so",
-                          "-Wl,-rpath='$$ORIGIN/../deps'",
+                          "../build/deps/librdkafka.a",
+                          "../build/deps/librdkafka++.a",
+                          "-lm",
+                          "-lz",
+                          "-lrt",
+                          "-ldl",
+                          "-lpthread"
                         ],
+                        'conditions': [
+                          [
+                            "SASL==\"y\"",
+                            {
+                              "libraries": [ "-lsasl2" ]
+                            }
+                          ]
+                        ]
                       }
                     ],
                     [


### PR DESCRIPTION
Gets ssl to work with node10 and above on centos 7 by statically
linking librdkafka.

The problem is that centos 7 uses openssl 1.0 where as node10+ is
statically linked to openssl 1.1. As this library first compiles
librafka, which is intern dynamically linked to the version of
openssl that is installed on the OS and not the version included
in node, this can cause instability.

Luckily librdkafka also includes the .a files for statically
linking librdkafka which we can then use to stically link the
library and hense force librdkafka/node-rdkafka to use the version
of openssl included within node.

Signed-off-by: Joshua Houghton <joshua.j.houghton@googlemail.com>