### PR TITLE
Make module self-register (Worker threads fix)

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -7,8 +7,6 @@
  * of the MIT license.  See the LICENSE.txt file for details.
  */
 
-module.exports = Producer;
-
 var Client = require('./client');
 
 var util = require('util');
@@ -289,3 +287,5 @@ Producer.prototype.disconnect = function(timeout, cb) {
     self._disconnect(cb);
   });
 };
+
+module.exports = Producer;

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -73,13 +73,11 @@ void ConstantsInit(v8::Local<v8::Object> exports) {
     Nan::GetFunction(Nan::New<v8::FunctionTemplate>(NodeRdKafkaBuildInFeatures)).ToLocalChecked());  // NOLINT
 }
 
-void Init(v8::Local<v8::Object> exports, v8::Local<v8::Context> context) {
+void Init(v8::Local<v8::Object> exports) {
 #if NODE_MAJOR_VERSION <= 9 || (NODE_MAJOR_VERSION == 10 && NODE_MINOR_VERSION <= 15)
   AtExit(RdKafkaCleanup);
 #else
-  #if !((NODE_MAJOR_VERSION >= 10 && NODE_MINOR_VERSION >= 7) || NODE_MAJOR_VERSION >= 11)
-  context = Nan::GetCurrentContext();
-  #endif
+  v8::Local<v8::Context> context = Nan::GetCurrentContext();
   node::Environment* env = node::GetCurrentEnvironment(context);
   AtExit(env, RdKafkaCleanup, NULL);
 #endif
@@ -93,13 +91,4 @@ void Init(v8::Local<v8::Object> exports, v8::Local<v8::Context> context) {
       Nan::New(RdKafka::version_str().c_str()).ToLocalChecked());
 }
 
-#if (NODE_MAJOR_VERSION >= 10 && NODE_MINOR_VERSION >= 7) || NODE_MAJOR_VERSION >= 11
-  // Initialize this module with proper Worker-compatible context
-  #define NODE_GYP_MODULE_NAME kafka // Default value is target_name "node-librdkafka", but the hyphen breaks macro
-  NODE_MODULE_INIT(/* exports, module, context */) {
-    Init(exports, context);
-  }
-#else
-  // Initialize this module with legacy context for backwards compatibility
-  NODE_MODULE(kafka, Init);
-#endif
+NAN_MODULE_WORKER_ENABLED(kafka, Init)

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -73,7 +73,7 @@ void ConstantsInit(v8::Local<v8::Object> exports) {
     Nan::GetFunction(Nan::New<v8::FunctionTemplate>(NodeRdKafkaBuildInFeatures)).ToLocalChecked());  // NOLINT
 }
 
-void Init(v8::Local<v8::Object> exports, v8::Local<v8::Context> context/*, v8::Local<v8::Value> m_, void* v_*/) {
+void Init(v8::Local<v8::Object> exports, v8::Local<v8::Context> context) {
 #if NODE_MAJOR_VERSION <= 9 || (NODE_MAJOR_VERSION == 10 && NODE_MINOR_VERSION <= 15)
   AtExit(RdKafkaCleanup);
 #else
@@ -94,12 +94,12 @@ void Init(v8::Local<v8::Object> exports, v8::Local<v8::Context> context/*, v8::L
 }
 
 #if (NODE_MAJOR_VERSION >= 10 && NODE_MINOR_VERSION >= 7) || NODE_MAJOR_VERSION >= 11
-  // Initialize this addon to be context-aware
-  #define NODE_GYP_MODULE_NAME kafka // the default name is target_name "node-librdkafka", but the hyphen breaks macro
+  // Initialize this module with proper Worker-compatible context
+  #define NODE_GYP_MODULE_NAME kafka // Default value is target_name "node-librdkafka", but the hyphen breaks macro
   NODE_MODULE_INIT(/* exports, module, context */) {
     Init(exports, context);
   }
 #else
-  // For backwards compatibility
+  // Initialize this module with legacy context for backwards compatibility
   NODE_MODULE(kafka, Init);
 #endif

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -95,7 +95,7 @@ void Init(v8::Local<v8::Object> exports, v8::Local<v8::Context> context/*, v8::L
 
 #if (NODE_MAJOR_VERSION >= 10 && NODE_MINOR_VERSION >= 7) || NODE_MAJOR_VERSION >= 11
   // Initialize this addon to be context-aware
-  #define NODE_GYP_MODULE_NAME kafka
+  #define NODE_GYP_MODULE_NAME kafka // the default name is target_name "node-librdkafka", but the hyphen breaks macro
   NODE_MODULE_INIT(/* exports, module, context */) {
     Init(exports, context);
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -14,8 +14,13 @@ module.exports = {
   'Node package': {
     'should not throw an error when module is loaded inside a worker': function() {
       t.doesNotThrow(function() {
-        new worker.Worker('require("./librdkafka.js")', { eval: true })
-      })
+        new worker.Worker(`
+          const t = require('assert');
+          const { isMainThread } = require('worker_threads');
+          t.strictEqual(isMainThread, false);
+          require("./librdkafka.js");
+        `, { eval: true });
+      });
     },
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -14,10 +14,7 @@ module.exports = {
   'Node package': {
     'should not throw an error when module is loaded inside a worker': function() {
       t.doesNotThrow(function() {
-        const code = `
-          require('../build/Release/node-librdkafka')
-        `
-        new worker.Worker(code, { eval: true })
+        new worker.Worker('require("./librdkafka.js")', { eval: true })
       })
     },
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,3 +6,19 @@
  * This software may be modified and distributed under the terms
  * of the MIT license.  See the LICENSE.txt file for details.
  */
+
+const worker = require('worker_threads');
+const t = require('assert');
+
+module.exports = {
+  'Node package': {
+    'should not throw an error when module is loaded inside a worker': function() {
+      t.doesNotThrow(function() {
+        const code = `
+          require('../build/Release/node-librdkafka')
+        `
+        new worker.Worker(code, { eval: true })
+      })
+    },
+  }
+}


### PR DESCRIPTION
`node-rdkafka` was incompatible with Worker threads due to legacy context awareness, this fixes the issue for relevant versions of Node.js (>=10.7.0), retaining the old behavior for versions before that. Giving credit where its due, used guidance from https://github.com/nodejs/node/issues/21783#issuecomment-429637117 and work already made in the [node-lzo](https://github.com/schroffl/node-lzo) code base.
Test included.
Resolves #831.