### PR TITLE
Handle consumer topic errors in librdkafka v1.5.0+ (#863)

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ The following table lists events for this API.
 |-------|----------|
 |`data` | When using the Standard API consumed messages are emitted in this event. |
 |`partition.eof` | When using Standard API and the configuration option `enable.partition.eof` is set, `partition.eof` events are emitted in this event. The event contains `topic`, `partition` and `offset` properties. |
+|`warning` | The event is emitted in case of `UNKNOWN_TOPIC_OR_PART` or `TOPIC_AUTHORIZATION_FAILED` errors when consuming in *Flowing mode*. Since the consumer will continue working if the error is still happening, the warning event should reappear after the next metadata refresh. To control the metadata refresh rate set `topic.metadata.refresh.interval.ms` property. Once you resolve the error, you can manually call `getMetadata` to speed up consumer recovery. |
 |`disconnected` | The `disconnected` event is emitted when the broker disconnects. <br><br>This event is only emitted when `.disconnect` is called. The wrapper will always try to reconnect otherwise. |
 |`ready` | The `ready` event is emitted when the `Consumer` is ready to read messages. |
 |`event` | The `event` event is emitted when `librdkafka` reports an event (if you opted in via the `event_cb` option).|

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -228,7 +228,7 @@ describe('Consumer/Producer', function() {
       
       consumer.once('partition.eof', function(eof) {
         events.push("partition.eof");
-      })
+      });
 
       setTimeout(function() {
         producer.produce(topic, null, buffer, null);
@@ -362,8 +362,23 @@ describe('Consumer/Producer', function() {
             startOffset + 2 ]);
         done();
       }, 6000);
-    })
-  })
+    });
+  });
+
+  it('should emit [warning] event on UNKNOWN_TOPIC_OR_PART error: consumeLoop', function(done) {
+    consumer.on('warning', function (err) {
+      if (err.code === Kafka.CODES.ERRORS.ERR_UNKNOWN_TOPIC_OR_PART) {
+        consumer.disconnect(function() {
+          done();
+        });
+      } else {
+        t.ifError(err);
+      }
+    });
+
+    consumer.subscribe(['non_existing_topic']);
+    consumer.consume();
+  });
 
   it('should be able to produce and consume messages with one header value as string: consumeLoop', function(done) {
     var headers = [

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -426,7 +426,7 @@ KafkaConsumer.prototype.consume = function(number, cb) {
 KafkaConsumer.prototype._consumeLoop = function(timeoutMs, cb) {
   var self = this;
   var retryReadInterval = this._consumeLoopTimeoutDelay;
-  self._client.consumeLoop(timeoutMs, retryReadInterval, function readCallback(err, message, eofEvent) {
+  self._client.consumeLoop(timeoutMs, retryReadInterval, function readCallback(err, message, eofEvent, warning) {
 
     if (err) {
       // A few different types of errors here
@@ -436,6 +436,8 @@ KafkaConsumer.prototype._consumeLoop = function(timeoutMs, cb) {
       cb(LibrdKafkaError.create(err));
     } else if (eofEvent) {
       self.emit('partition.eof', eofEvent);
+    } else if (warning) {
+      self.emit('warning', LibrdKafkaError.create(warning));
     } else {
       /**
        * Data event. called whenever a message is received.


### PR DESCRIPTION
This PR should handle the consumer topic errors (#863) that are right now making a breaking change in the "flowing mode" consumer.

More info:
https://github.com/edenhill/librdkafka/issues/1540
https://github.com/edenhill/librdkafka/wiki/Proposal:-Consumer-topic-error-handling