### PR TITLE
Use C++14 to be able to build using node v16.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ node_js:
   - "13"
   - "14"
   - "15"
+  - "16"
 sudo: required
 services: docker
 before_install:

--- a/binding.gyp
+++ b/binding.gyp
@@ -43,7 +43,7 @@
               }
             ],
             'cflags_cc' : [
-              '-std=c++11'
+              '-std=c++14'
             ],
             'msvs_settings': {
               'VCLinkerTool': {
@@ -122,7 +122,7 @@
                 'OS=="linux"',
                 {
                   'cflags_cc' : [
-                    '-std=c++11'
+                    '-std=c++14'
                   ],
                   'cflags_cc!': [
                     '-fno-rtti'
@@ -140,7 +140,7 @@
                     ],
                     'OTHER_CPLUSPLUSFLAGS': [
                       '-I/usr/local/opt/openssl/include',
-                      '-std=c++11'
+                      '-std=c++14'
                     ],
                   },
                 }


### PR DESCRIPTION
Tries to fix #885 