### PR TITLE
Specify absolute path to win action in binding.gyp and minor fixes to windows-install.py

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -32,7 +32,7 @@
               {
                 'action_name': 'nuget_librdkafka_download',
                 'inputs': [
-                  'deps/windows-install.py'
+                  '<(module_root_dir)/deps/windows-install.py'
                 ],
                 'outputs': [
                   'deps/precompiled/librdkafka.lib',

--- a/deps/windows-install.py
+++ b/deps/windows-install.py
@@ -4,7 +4,7 @@ import json
 import os
 with open('../package.json') as f:
     librdkafkaVersion = json.load(f)['librdkafka']
-librdkafkaWinSufix = '7' if librdkafkaVersion == '0.11.5' else '';
+librdkafkaWinSufix = '7' if librdkafkaVersion == '0.11.5' else ''
 
 depsPrecompiledDir = '../deps/precompiled'
 depsIncludeDir = '../deps/include'
@@ -14,7 +14,7 @@ buildReleaseDir = 'Release'
 env_dist = os.environ
 downloadBaseUrl = env_dist['NODE_RDKAFKA_NUGET_BASE_URL'] if 'NODE_RDKAFKA_NUGET_BASE_URL' in env_dist else 'https://globalcdn.nuget.org/packages/'
 librdkafkaNugetUrl = downloadBaseUrl + 'librdkafka.redist.{}.nupkg'.format(librdkafkaVersion)
-print 'download librdkafka form ' + librdkafkaNugetUrl
+print('download librdkafka form ' + librdkafkaNugetUrl)
 outputDir = 'librdkafka.redist'
 outputFile = outputDir + '.zip'
 dllPath = outputDir + '/runtimes/win{}-x64/native'.format(librdkafkaWinSufix)


### PR DESCRIPTION
Refer to https://github.com/nodejs/node-gyp/issues/2485 why absolute path is needed when using latest `node-gyp`.