### PR TITLE
provide TopicPartitionOffset to HighLevelProducer callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,10 @@ export interface ClientMetrics {
     connectionOpened: number;
 }
 
+export interface HighLevelProducerOptions {
+    cb_topicPartitionOffset?: boolean;
+}
+
 export interface MetadataOptions {
     topic?: string;
     allTopics?: boolean;
@@ -75,6 +79,8 @@ export interface TopicPartition {
 export interface TopicPartitionOffset extends TopicPartition{
     offset: number;
 }
+
+type HighLevelProducerCallback = (err: any, offset?: NumberNullUndefined | TopicPartitionOffset) => void
 
 export type TopicPartitionTime = TopicPartitionOffset;
 
@@ -278,8 +284,10 @@ export class Producer extends Client<KafkaProducerEvents> {
 }
 
 export class HighLevelProducer extends Producer {
-  produce(topic: string, partition: NumberNullUndefined, message: any, key: any, timestamp: NumberNullUndefined, callback: (err: any, offset?: NumberNullUndefined) => void): any;
-  produce(topic: string, partition: NumberNullUndefined, message: any, key: any, timestamp: NumberNullUndefined, headers: MessageHeader[], callback: (err: any, offset?: NumberNullUndefined) => void): any;
+  constructor(conf: ProducerGlobalConfig, topicConf?: ProducerTopicConfig, highLevelConf?: HighLevelProducerOptions);
+
+  produce(topic: string, partition: NumberNullUndefined, message: any, key: any, timestamp: NumberNullUndefined, callback: HighLevelProducerCallback): any;
+  produce(topic: string, partition: NumberNullUndefined, message: any, key: any, timestamp: NumberNullUndefined, headers: MessageHeader[], callback: HighLevelProducerCallback): any;
 
   setKeySerializer(serializer: (key: any, cb: (err: any, key: MessageKey) => void) => void): void;
   setKeySerializer(serializer: (key: any) => MessageKey | Promise<MessageKey>): void;

--- a/lib/producer/high-level-producer.js
+++ b/lib/producer/high-level-producer.js
@@ -79,7 +79,7 @@ function createSerializer(serializer) {
  * @extends Producer
  * @constructor
  */
-function HighLevelProducer(conf, topicConf) {
+function HighLevelProducer(conf, topicConf, highLevelConf) {
   if (!(this instanceof HighLevelProducer)) {
     return new HighLevelProducer(conf, topicConf);
   }
@@ -127,7 +127,16 @@ function HighLevelProducer(conf, topicConf) {
   // Listen to all delivery reports to propagate elements with a _message_id to the emitter
   this.on('delivery-report', function(err, report) {
     if (report.opaque && report.opaque.__message_id !== undefined) {
-      self._hl.deliveryEmitter.emit(report.opaque.__message_id, err, report.offset);
+      var offset = report.offset;
+      if (highLevelConf.cb_topicPartitionOffset) {
+        offset = {
+          topic: report.topic,
+          partition: report.partition,
+          offset: report.offset
+        }
+      }
+
+      self._hl.deliveryEmitter.emit(report.opaque.__message_id, err, offset);
     }
   });
 


### PR DESCRIPTION
I was disappointed that I couldn't get all three of topic, partition, and offset from Delivery Report in my HighLevelProducer callback function, the offset alone seemed somehow incomplete.

I hope someone may find this extension useful.