### PR TITLE
Simplify e2e tests removing random timeout values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ check: node_modules/.dirstamp
 	@$(NODE) util/test-compile.js
 
 e2e: $(E2E_TESTS)
-	@./node_modules/.bin/mocha --exit $(TEST_REPORTER) $(E2E_TESTS) $(TEST_OUTPUT)
+	@./node_modules/.bin/mocha --exit --timeout 120000 $(TEST_REPORTER) $(E2E_TESTS) $(TEST_OUTPUT)
 
 define release
 	NEXT_VERSION=$(shell node -pe 'require("semver").inc("$(VERSION)", "$(1)")')

--- a/e2e/admin.spec.js
+++ b/e2e/admin.spec.js
@@ -90,7 +90,6 @@ describe('Admin', function() {
   });
 
   beforeEach(function() {
-    this.timeout(10000);
     client = Kafka.AdminClient.create({
       'client.id': 'kafka-test',
       'metadata.broker.list': kafkaBrokerList
@@ -100,7 +99,6 @@ describe('Admin', function() {
   describe('createTopic', function() {
     it('should create topic sucessfully', function(done) {
       var topicName = 'admin-test-topic-' + time;
-      this.timeout(30000);
       client.createTopic({
         topic: topicName,
         num_partitions: 1,
@@ -115,7 +113,6 @@ describe('Admin', function() {
 
     it('should raise an error when replication_factor is larger than number of brokers', function(done) {
       var topicName = 'admin-test-topic-bad-' + time;
-      this.timeout(30000);
       client.createTopic({
         topic: topicName,
         num_partitions: 9999,
@@ -130,7 +127,6 @@ describe('Admin', function() {
   describe('deleteTopic', function() {
     it('should be able to delete a topic after creation', function(done) {
       var topicName = 'admin-test-topic-2bdeleted-' + time;
-      this.timeout(30000);
       client.createTopic({
         topic: topicName,
         num_partitions: 1,
@@ -151,7 +147,6 @@ describe('Admin', function() {
   describe('createPartitions', function() {
     it('should be able to add partitions to a topic after creation', function(done) {
       var topicName = 'admin-test-topic-newparts-' + time;
-      this.timeout(30000);
       client.createTopic({
         topic: topicName,
         num_partitions: 1,
@@ -173,7 +168,6 @@ describe('Admin', function() {
 
     it('should NOT be able to reduce partitions to a topic after creation', function(done) {
       var topicName = 'admin-test-topic-newparts2-' + time;
-      this.timeout(30000);
       client.createTopic({
         topic: topicName,
         num_partitions: 4,

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -85,7 +85,6 @@ describe('Consumer/Producer', function() {
   });
 
   afterEach(function(done) {
-    this.timeout(6000);
     var finished = 0;
     var called = false;
 
@@ -115,7 +114,6 @@ describe('Consumer/Producer', function() {
   });
 
   it('should be able to produce, consume messages, read position: subscribe/consumeOnce', function(done) {
-    this.timeout(8000);
     crypto.randomBytes(4096, function(ex, buffer) {
       producer.setPollInterval(10);
 
@@ -167,7 +165,6 @@ describe('Consumer/Producer', function() {
   });
   
   it('should return ready messages on partition EOF', function(done) {
-    this.timeout(8000);
     crypto.randomBytes(4096, function(ex, buffer) {
       producer.setPollInterval(10);
 
@@ -210,7 +207,6 @@ describe('Consumer/Producer', function() {
   });
 
   it('should emit partition.eof event when reaching end of partition', function(done) {
-    this.timeout(8000);
     crypto.randomBytes(4096, function(ex, buffer) {
       producer.setPollInterval(10);
 
@@ -244,7 +240,6 @@ describe('Consumer/Producer', function() {
   });
 
   it('should emit partition.eof when already at end of partition', function(done) {
-    this.timeout(8000);
     crypto.randomBytes(4096, function(ex, buffer) {
       producer.setPollInterval(10);
 
@@ -280,8 +275,6 @@ describe('Consumer/Producer', function() {
   it('should be able to produce and consume messages: consumeLoop', function(done) {
     var key = 'key';
 
-    this.timeout(5000);
-
     crypto.randomBytes(4096, function(ex, buffer) {
 
       producer.setPollInterval(10);
@@ -313,7 +306,6 @@ describe('Consumer/Producer', function() {
   });
 
   it('should emit \'partition.eof\' events in consumeLoop', function(done) {
-    this.timeout(7000);
 
     crypto.randomBytes(4096, function(ex, buffer) {
       producer.setPollInterval(10);
@@ -384,7 +376,6 @@ describe('Consumer/Producer', function() {
     var headers = [
       { key: "value" }
     ];
-    this.timeout(5000);
     run_headers_test(done, headers);
   });
 
@@ -392,7 +383,6 @@ describe('Consumer/Producer', function() {
     var headers = [
       { key: Buffer.from('value') }
     ];
-    this.timeout(5000);
     run_headers_test(done, headers);
   });
 
@@ -400,7 +390,6 @@ describe('Consumer/Producer', function() {
     var headers = [
       { key: 10 }
     ];
-    this.timeout(5000);
     run_headers_test(done, headers);
   });
 
@@ -408,7 +397,6 @@ describe('Consumer/Producer', function() {
     var headers = [
       { key: 1.11 }
     ];
-    this.timeout(5000);
     run_headers_test(done, headers);
   });
 
@@ -419,7 +407,6 @@ describe('Consumer/Producer', function() {
       { key3: Buffer.from('value3') },
       { key4: Buffer.from('value4') },
     ];
-    this.timeout(5000);
     run_headers_test(done, headers);
   });
   
@@ -430,7 +417,6 @@ describe('Consumer/Producer', function() {
       { key3: 'value3' },
       { key4: 'value4' },
     ];
-    this.timeout(5000);
     run_headers_test(done, headers);
   });
 
@@ -441,12 +427,10 @@ describe('Consumer/Producer', function() {
       { key3: 100 },
       { key4: 10.1 },
     ];
-    this.timeout(5000);
     run_headers_test(done, headers);
   });
 
   it('should be able to produce and consume messages: empty buffer key and empty value', function(done) {
-    this.timeout(20000);
     var emptyString = '';
     var key = Buffer.from(emptyString);
     var value = Buffer.from('');
@@ -469,7 +453,6 @@ describe('Consumer/Producer', function() {
   });
 
   it('should be able to produce and consume messages: empty key and empty value', function(done) {
-    this.timeout(20000);
     var key = '';
     var value = Buffer.from('');
 
@@ -491,7 +474,6 @@ describe('Consumer/Producer', function() {
   });
 
   it('should be able to produce and consume messages: null key and null value', function(done) {
-    this.timeout(20000);
     var key = null;
     var value = null;
 
@@ -538,14 +520,12 @@ describe('Consumer/Producer', function() {
     });
 
     afterEach(function(done) {
-      this.timeout(10000);
       consumer.disconnect(function() {
         done();
       });
     });
 
     it('should async commit after consuming', function(done) {
-      this.timeout(25000);
       var key = '';
       var value = Buffer.from('');
 
@@ -596,15 +576,12 @@ describe('Consumer/Producer', function() {
     var grp = 'kafka-mocha-grp-' + crypto.randomBytes(20).toString('hex');
 
     afterEach(function(done) {
-      this.timeout(10000);
       consumer.disconnect(function() {
         done();
       });
     });
 
     it('should callback offset_commit_cb after commit', function(done) {
-      this.timeout(20000);
-
       var consumerOpts = {
           'metadata.broker.list': kafkaBrokerList,
           'group.id': grp,

--- a/e2e/consumer.spec.js
+++ b/e2e/consumer.spec.js
@@ -110,7 +110,6 @@ describe('Consumer', function() {
     });
 
     it('after assign and commit, should get committed offsets', function(done) {
-      this.timeout(6000);
       consumer.assign([{topic:topic, partition:0}]);
       consumer.commitSync({topic:topic, partition:0, offset:1000});
       consumer.committed(null, 1000, function(err, committed) {
@@ -301,8 +300,6 @@ describe('Consumer', function() {
     });
 
     it('should happen without issue after consuming', function(cb) {
-      this.timeout(11000);
-
       var consumer = new KafkaConsumer(gcfg, tcfg);
       consumer.setDefaultConsumeTimeout(10000);
 

--- a/e2e/groups.spec.js
+++ b/e2e/groups.spec.js
@@ -68,7 +68,6 @@ describe('Consumer group/Producer', function() {
   });
 
   it('should be able to commit, read committed and restart from the committed offset', function(done) {
-    this.timeout(30000);
     var topic = 'test';
     var key = 'key';
     var payload = Buffer.from('value');

--- a/e2e/producer-transaction.spec.js
+++ b/e2e/producer-transaction.spec.js
@@ -12,7 +12,6 @@ var Kafka = require('../');
 var kafkaBrokerList = process.env.KAFKA_HOST || 'localhost:9092';
 
 describe('Transactional Producer', function () {
-  this.timeout(5000);
   var TRANSACTIONS_TIMEOUT_MS = 30000;
   var r = Date.now() + '_' + Math.round(Math.random() * 1000);
   var topicIn = 'transaction_input_' + r;

--- a/e2e/producer.spec.js
+++ b/e2e/producer.spec.js
@@ -59,8 +59,6 @@ describe('Producer', function() {
     });
 
     it('should produce a message with a null payload and null key', function(done) {
-      this.timeout(3000);
-
       var tt = setInterval(function() {
         producer.poll();
       }, 200);
@@ -80,8 +78,6 @@ describe('Producer', function() {
     });
 
     it('should produce a message with a payload and key', function(done) {
-      this.timeout(3000);
-
       var tt = setInterval(function() {
         producer.poll();
       }, 200);
@@ -102,8 +98,6 @@ describe('Producer', function() {
     });
 
     it('should produce a message with a payload and key buffer', function(done) {
-      this.timeout(3000);
-
       var tt = setInterval(function() {
         producer.poll();
       }, 200);
@@ -124,8 +118,6 @@ describe('Producer', function() {
     });
 
     it('should produce a message with an opaque', function(done) {
-      this.timeout(3000);
-
       var tt = setInterval(function() {
         producer.poll();
       }, 200);
@@ -146,8 +138,6 @@ describe('Producer', function() {
 
 
     it('should get 100% deliverability', function(done) {
-      this.timeout(3000);
-
       var total = 0;
       var max = 10000;
       var verified_received = 0;
@@ -202,8 +192,6 @@ describe('Producer', function() {
     });
 
     it('should produce a message with a payload and key', function(done) {
-      this.timeout(3000);
-
       var tt = setInterval(function() {
         producer.poll();
       }, 200);
@@ -224,8 +212,6 @@ describe('Producer', function() {
     });
 
     it('should produce a message with an empty payload and empty key (https://github.com/Blizzard/node-rdkafka/issues/117)', function(done) {
-      this.timeout(3000);
-
       var tt = setInterval(function() {
         producer.poll();
       }, 200);
@@ -247,8 +233,6 @@ describe('Producer', function() {
     });
 
     it('should produce a message with a null payload and null key  (https://github.com/Blizzard/node-rdkafka/issues/117)', function(done) {
-      this.timeout(3000);
-
       producer.setPollInterval(10);
 
       producer.once('delivery-report', function(err, report) {
@@ -292,7 +276,6 @@ describe('Producer', function() {
 
       producer.produce('test', null, null, Buffer.from(arr.buffer));
 
-      this.timeout(3000);
     });
 
   });


### PR DESCRIPTION
This commit helps to run integration tests in different environments
other than localhost kafka.

It also helps by cleaning up the integration tests a bit.