### PR TITLE
Add support for Buffer types in Kafka Headers

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -439,7 +439,7 @@ v8::Local<v8::Object> ToV8Object(RdKafka::Message *message,
                                                      it != all.end(); it++) {
         v8::Local<v8::Object> v8header = Nan::New<v8::Object>();
         Nan::Set(v8header, Nan::New<v8::String>(it->key()).ToLocalChecked(),
-          Nan::Encode(it->value_string(),
+          Nan::Encode(it->value(),
             it->value_size(), Nan::Encoding::BUFFER));
         Nan::Set(v8headers, index, v8header);
         index++;


### PR DESCRIPTION
The node-rdkafka API accepts Buffers or strings in KafkaHeaders (in line with the librdkafka API), but converts all Header Values to strings. You can test this by attempting to send a Header value such a Buffer generated from a Uint8 array with values above 127 or including 0s. The first 0 encountered will be treated as a null termination, and bytes above 127 will be spread across multiple array entries, changing the length and values of the uint8 array.