### PR TITLE
Docs: fix alpine example due to python version

### DIFF
--- a/examples/docker-alpine.md
+++ b/examples/docker-alpine.md
@@ -3,7 +3,7 @@ When using docker to install `node-rdkafka`, you need to make sure you install a
 You can see some of the differences here: https://linuxacademy.com/blog/cloud/alpine-linux-and-docker/
 
 ```dockerfile
-FROM node:8-alpine
+FROM node:14-alpine
 
 RUN apk --no-cache add \
       bash \

--- a/examples/docker-alpine.md
+++ b/examples/docker-alpine.md
@@ -14,7 +14,7 @@ RUN apk --no-cache add \
       cyrus-sasl-dev \
       openssl-dev \
       make \
-      python
+      python3
 
 RUN apk add --no-cache --virtual .build-deps gcc zlib-dev libc-dev bsd-compat-headers py-setuptools bash
 


### PR DESCRIPTION
Fixes the Alpine example, which [removed](https://git.alpinelinux.org/aports/commit/?h=3.12-stable&id=5ad0ec7da1064361cc74d56edf7524960f49ef9b) the generic `python` package in v3.12.

node-gyp supports python3 since v5.x:
https://github.com/nodejs/node-gyp/blob/master/CHANGELOG.md
