### PR TITLE
fix: release opaque data on error in produce

### DIFF
--- a/src/producer.cc
+++ b/src/producer.cc
@@ -629,6 +629,17 @@ NAN_METHOD(Producer::NodeProduce) {
     error_code = static_cast<int>(b.err());
   }
 
+  if (error_code != 0 && opaque) {
+    // If there was an error enqueing this message, there will never
+    // be a delivery report for it, so we have to clean up the opaque
+    // data now, if there was any.
+
+    Nan::Persistent<v8::Value> *persistent =
+      static_cast<Nan::Persistent<v8::Value> *>(opaque);
+    persistent->Reset();
+    delete persistent;
+  }
+
   if (key != NULL) {
     delete key;
   }


### PR DESCRIPTION
When there is an error trying to produce() messages,
no delivery report is ever generated for the message.
If the user specified `opaque` data for the message,
the call to produce() will have "pinned" it, but with
no delivery report, it is never released.  This change
checks for this condition and releases the opaque
data when this happens.

Fixes: #953