### PR TITLE
Report error instead of returning EOFs when no other messages have been seen so far in KafkaConsumerConsumeNum

### DIFF
--- a/src/workers.cc
+++ b/src/workers.cc
@@ -836,14 +836,14 @@ void KafkaConsumerConsumeNum::Execute() {
         default:
           // Set the error for any other errors and break
           delete message;
-          if (m_messages.size() == 0) {
+          if (m_messages.size() == eof_event_count) {
             SetErrorBaton(Baton(errorCode));
           }
           looping = false;
           break;
       }
     } else {
-      if (m_messages.size() == 0) {
+      if (m_messages.size() == eof_event_count) {
         SetErrorBaton(b);
       }
       looping = false;


### PR DESCRIPTION
In KafkaConsumerConsumeNum, we forget errors when we've already seen some messages,
because we can only return an error or messages, and the messages are more important.

Additionally, the error could be re-fetched when fetching another time at the higher offset, as no
new messages will be available then and the error will thus be returned.

This logic breaks when returning EOFs: EOFs will be returned even if we're at the end of a partition.
But it's still important to see errors, and arguably it's more important.
So, if we've only seen EOFs so far, we should return the error when encountering one.

This would help us in receiving OffsetOutOfRange errors, which is important for us to detect.