### PR TITLE
Fix bug that header values are not null-terminated

### DIFF
--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -409,6 +409,27 @@ describe('Consumer/Producer', function() {
     ];
     run_headers_test(done, headers);
   });
+
+  it('should be able to produce and consume messages with one header with NULL byte', function(done) {
+    var b = Buffer.alloc(3);
+    b.writeUInt8(1, 0);
+    b.writeUInt8(0, 1);
+    b.writeUInt8(1, 2);
+    var headers = [
+      { key1: b },
+    ];
+    run_headers_test(done, headers);
+  });
+
+  it('should be able to produce and consume messages with one header with partial UTF-8 sequences byte', function(done) {
+    //first three bytes encode the euro sign '€' in UTF-8, the fourth byte marks the beginning of a three byte UTF-8 code, 
+    //followed by a single byte UTF-8 code encoding the dollar sign, therefore the fourth byte is a partial UTF-8 sequence
+    var b = Buffer.from([0xE2, 0x82, 0xAC, 0xE2, 0x24]);
+    var headers = [
+      { key1: b },
+    ];
+    run_headers_test(done, headers);
+  });
   
   it('should be able to produce and consume messages with multiple headers value as string: consumeLoop', function(done) {
     var headers = [
@@ -621,11 +642,14 @@ describe('Consumer/Producer', function() {
       var messageKey = Object.keys(messageHeaders[i]);
       t.equal(messageKey.length, 1, 'Expected only one Header key');
       t.equal(expectedKey, messageKey[0], 'Expected key does not match message key');
-      var expectedValue = Buffer.isBuffer(expectedHeaders[i][expectedKey]) ?
-                          expectedHeaders[i][expectedKey].toString() :
-                          expectedHeaders[i][expectedKey];
-      var actualValue = messageHeaders[i][expectedKey].toString();
-      t.equal(expectedValue, actualValue, 'invalid message header');
+      var expectedValue = expectedHeaders[i][expectedKey];
+      var actualValue = messageHeaders[i][expectedKey];
+      if (Buffer.isBuffer(expectedValue)) {
+        t.deepStrictEqual(expectedValue, actualValue, 'invalid message header');
+      } else {
+        actualValue = actualValue.toString();
+        t.equal(expectedValue, actualValue, 'invalid message header')
+      }
     }
   }
 


### PR DESCRIPTION
There are currently two bugs in the producer code when dealing with buffers as header values.

The first issue is that the data of buffers passed as header values is cut off on the first null byte. According to the documentation (see https://kafka.apache.org/documentation/#recordheader) headers of Kafka messages can be arbitrary byte sequences. The bug is caused by the use of the copy constructor in `std::string`, which stops copying on the null byte. Using the copy constructor where the length of the byte sequence is passed explicitly will fix this issue.

A second issue is that a buffer is treated similar to a string and that its content is passed to the UTF8String constructor. This will modify the byte sequence, as this constructor will transform the passed data from the node internal UTF-16 string representation into a UTF-8 representation. Since buffers can be arbitrarily encoded data and not necessarily strings, buffers should not be passed to the UTF8String constructor. Instead, their value should be used as is.