### PR TITLE
Improve type definitions for config callbacks

### DIFF
--- a/ci/librdkafka-defs-generator.js
+++ b/ci/librdkafka-defs-generator.js
@@ -57,11 +57,11 @@ function processItem(configItem) {
     case 'dr_msg_cb':
       return { ...configItem, type: 'boolean' };
     case 'dr_cb':
-      return { ...configItem, type: 'boolean | Function' };
+      return { ...configItem, type: 'boolean | ((this: import("./").KafkaProducer, err: import("./").LibrdKafkaError, report: import("./").DeliveryReport) => void)' };
     case 'rebalance_cb':
-      return { ...configItem, type: 'boolean | Function' };
+      return { ...configItem, type: 'boolean | ((this: import("./").KafkaConsumer, err: import("./").LibrdKafkaError, assignment: import("./").Assignment[]) => void)' };
     case 'offset_commit_cb':
-      return { ...configItem, type: 'boolean | Function' };
+      return { ...configItem, type: 'boolean | ((this: import("./").KafkaConsumer, err: import("./").LibrdKafkaError, assignment: import("./").TopicPartitionOffset[]) => void)' };
   }
 
   switch (configItem.rawType) {


### PR DESCRIPTION
When working with strict type checking in typescript, the callbacks `dr_cb`, `rebalance_cb` and `offset_commit_cb` are not sufficiently typed, and even the examples given in the README are throwing type errors.

This PR defines strict types for these callbacks.

I have done my best to back track the types from the `EventListenerMap` for [`rebalance`](https://github.com/Blizzard/node-rdkafka/blob/master/index.d.ts#L163), [`offset.commit `](https://github.com/Blizzard/node-rdkafka/blob/master/index.d.ts#L170) and [`delivery-report `](https://github.com/Blizzard/node-rdkafka/blob/master/index.d.ts#L173)

**Caveat 1:** I have not been able to build the project locally, so these changes are made based on the installed package from npm inside a project that consumes node-rdkafka

**Caveat 2:**. In my project, I am currently only using `rebalance_cb`, so the others have been harder to check.