### PR TITLE
Upgrade to mocha ^10.2.0 to reduce vulnerabilities.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,13 @@ $(CONFIG_OUTPUTS): node_modules/.dirstamp binding.gyp
 	@$(NODE-GYP) configure
 
 test: node_modules/.dirstamp
-	@./node_modules/.bin/mocha $(TEST_REPORTER) $(TESTS) $(TEST_OUTPUT)
+	@./node_modules/.bin/mocha $(TEST_REPORTER) $(TESTS) $(TEST_OUTPUT) --ui exports
 
 check: node_modules/.dirstamp
 	@$(NODE) util/test-compile.js
 
 e2e: $(E2E_TESTS)
-	@./node_modules/.bin/mocha --exit --timeout 120000 $(TEST_REPORTER) $(E2E_TESTS) $(TEST_OUTPUT)
+	@./node_modules/.bin/mocha --exit --timeout 120000 $(TEST_REPORTER) $(E2E_TESTS) $(TEST_OUTPUT) --ui exports
 
 define release
 	NEXT_VERSION=$(shell node -pe 'require("semver").inc("$(VERSION)", "$(1)")')

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bluebird": "^3.5.3",
     "jsdoc": "^3.4.0",
     "jshint": "^2.10.1",
-    "mocha": "^5.2.0",
+    "mocha": "^10.2.0",
     "node-gyp": "^8.4.1",
     "toolkit-jsdoc": "^1.0.0"
   },

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---ui exports


### PR DESCRIPTION
Mocha stopped support for mocha.opts at version 8.0.0 so the changes here simply add `--ui exports` so that `mocha` can be moved to the latest version.

This also eliminates a number of vulnerabilities as shown by `npm audit report` below:
```
# npm audit report

minimatch  <3.0.5
Severity: high
minimatch ReDoS vulnerability - https://github.com/advisories/GHSA-f8q6-p94x-37v3
fix available via `npm audit fix --force`
Will install mocha@10.2.0, which is a breaking change
node_modules/mocha/node_modules/minimatch
  mocha  1.21.5 - 9.2.1
  Depends on vulnerable versions of minimatch
  Depends on vulnerable versions of mkdirp
  node_modules/mocha

minimist  <=1.2.5
Severity: critical
Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h
Prototype Pollution in minimist - https://github.com/advisories/GHSA-vh95-rmgr-6w4m
fix available via `npm audit fix --force`
Will install mocha@10.2.0, which is a breaking change
node_modules/minimist
  mkdirp  0.4.1 - 0.5.1
  Depends on vulnerable versions of minimist
  node_modules/mocha/node_modules/mkdirp

4 vulnerabilities (1 moderate, 2 high, 1 critical)
```