### PR TITLE
Revert node engine change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,5 @@ jobs:
         run: npm ci
       # skipping on windows for now due to Make / mocha exit code issues
       - name: Test
-        if: runner.os != 'Windows' && runner.node != 10
+        if: runner.os != 'Windows' && matrix.node != 10
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,5 @@ jobs:
         run: npm ci
       # skipping on windows for now due to Make / mocha exit code issues
       - name: Test
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && runner.node != 10
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [14, 16, 18, 19]
+        node: [10, 12, 14, 16, 18, 19]
         os: [ubuntu-22.04]
         include:
           # single mac test due to minute multipliers
@@ -30,6 +30,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: "npm"
+      - name: Update node-gyp
+        run: npm install --global node-gyp@latest
       - name: Install Windows packages
         if: runner.os == 'Windows'
         run: ./win_install.ps1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-rdkafka",
-  "version": "v2.14.5",
+  "version": "v2.14.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-rdkafka",
-      "version": "v2.14.5",
+      "version": "v2.14.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -22,7 +22,7 @@
         "toolkit-jsdoc": "^1.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/parser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-rdkafka",
-  "version": "v2.14.5",
+  "version": "v2.14.6",
   "description": "Node.js bindings for librdkafka",
   "librdkafka": "1.9.2",
   "main": "lib/index.js",
@@ -43,6 +43,6 @@
     "nan": "^2.17.0"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=6.0.0"
   }
 }


### PR DESCRIPTION
Reverting node engine change. The engine requirement should only be updated in a major version
Fixes #999