### PR TITLE
Add examples to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ deps/librdkafka/config.h
 build
 .github
 .vscode
+deps/librdkafka/examples


### PR DESCRIPTION
One-liner to address issue https://github.com/Blizzard/node-rdkafka/issues/940

The `deps/librdkafka/examples` directory shouldn't be included in published artifacts, especially with how heavy it can make the package. It's also likely that most users will end up navigating to this repository for examples and usage anyways