### PR TITLE
consumer: fix consumeNum to respect the consume timeout

### DIFF
--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -262,7 +262,7 @@ describe('Consumer/Producer', function() {
       setTimeout(function() {
         producer.produce(topic, null, buffer, null);
       }, 2000)
-      consumer.setDefaultConsumeTimeout(3000);
+      consumer.setDefaultConsumeTimeout(5000);
       consumer.consume(1000, function(err, messages) {
         t.ifError(err);
         t.equal(messages.length, 1);

--- a/e2e/both.spec.js
+++ b/e2e/both.spec.js
@@ -229,7 +229,7 @@ describe('Consumer/Producer', function() {
       setTimeout(function() {
         producer.produce(topic, null, buffer, null);
       }, 500)
-      consumer.setDefaultConsumeTimeout(2000);
+      consumer.setDefaultConsumeTimeout(3000);
       consumer.consume(1000, function(err, messages) {
         t.ifError(err);
         t.equal(messages.length, 1);


### PR DESCRIPTION
Steps to reproduce the problem:
* configure consumer with `setDefaultConsumeTimeout(1000)`
* produce 1 message every 500ms
* call `consumer.consume(128, cb)`

Actual outcome:
* consume returns batch of 128 messages after 64 seconds

Expected outcome:
* consumer returns batch of ~2 messages after 1 second

KafkaConsumerConsumeNum call underlaying c++ `m_consumer->Consume`
in cycle until
* either the accumulated batch is full
* or the call to c++ m_consumer->Consume times out on the total timeout

KafkaConsumerConsumeNum must enforce its timeout
over all `m_consumer->Consume` invocations altogether.