### PR TITLE
docs: simplify contributing by adding instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ deps/*
 .DS_Store
 
 .vscode
+.idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ so if you feel something is missing feel free to send a pull request.
   * [Contributor Agreement](#contributor-agreement)
 
 [How Can I Contribute?](#how-can-i-contribute)
+  * [Setting up the repository](#setting-up-the-repository)
   * [Reporting Bugs](#reporting-bugs)
   * [Suggesting Enhancements](#suggesting-enhancements)
   * [Pull Requests](#pull-requests)
@@ -36,6 +37,14 @@ so if you feel something is missing feel free to send a pull request.
 Not currently required.
 
 ## How can I contribute?
+
+### Setting up the repository
+
+To set up the library locally, do the following:
+
+1) Clone this repository.
+2) Install librdkafka with `git submodule update --init --recursive`
+3) Install the dependencies `npm install`
 
 ### Reporting Bugs
 


### PR DESCRIPTION
I've spend quite a bit of time to figure out why the repo wasn't working on my machine, before I realized I needed to init the git submodule. In hindsight, it was very obvious, because that submodule is the point of this entire repo. Nevertheless it would have helped a lot to have these instructions.

Also, i use IntelliJ, so i've added `.idea` to the gitignore.