### PR TITLE
Allow passing null to commitSync in KafkaConsumer typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -218,7 +218,7 @@ export class KafkaConsumer extends Client<KafkaConsumerEvents> {
 
     commitMessageSync(msg: TopicPartitionOffset): this;
 
-    commitSync(topicPartition: TopicPartitionOffset | TopicPartitionOffset[]): this;
+    commitSync(topicPartition: TopicPartitionOffset | TopicPartitionOffset[] | null): this;
 
     committed(toppars: TopicPartition[], timeout: number, cb: (err: LibrdKafkaError, topicPartitions: TopicPartitionOffset[]) => void): this;
     committed(timeout: number, cb: (err: LibrdKafkaError, topicPartitions: TopicPartitionOffset[]) => void): this;


### PR DESCRIPTION
In the typings KafkaConsumer incorrectly requires that commitSync be called with a TopicPartitionOffset or an array of TopicPartitionOffsets, when docs say that null can be passed to commit all read offsets. This change allows null to be passed without resorting to hacks like `client.commitSync(null as any)`.