### PR TITLE
Export event types for use with abstract Client class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -142,9 +142,9 @@ export interface ConsumerStream extends Readable {
     close(cb?: () => void): void;
 }
 
-type KafkaClientEvents = 'disconnected' | 'ready' | 'connection.failure' | 'event.error' | 'event.stats' | 'event.log' | 'event.event' | 'event.throttle';
-type KafkaConsumerEvents = 'data' | 'partition.eof' | 'rebalance' | 'rebalance.error' | 'subscribed' | 'unsubscribed' | 'unsubscribe' | 'offset.commit' | KafkaClientEvents;
-type KafkaProducerEvents = 'delivery-report' | KafkaClientEvents;
+export type KafkaClientEvents = 'disconnected' | 'ready' | 'connection.failure' | 'event.error' | 'event.stats' | 'event.log' | 'event.event' | 'event.throttle';
+export type KafkaConsumerEvents = 'data' | 'partition.eof' | 'rebalance' | 'rebalance.error' | 'subscribed' | 'unsubscribed' | 'unsubscribe' | 'offset.commit' | KafkaClientEvents;
+export type KafkaProducerEvents = 'delivery-report' | KafkaClientEvents;
 
 type EventListenerMap = {
     // ### Client


### PR DESCRIPTION
Without exported event types, they must be duplicated in dependant code to correctly use the abstract `Client` class, which is needed when either a Producer or Consumer client could be the value of a class field. If no events are supplied to the `Client` class, then subscribing to event listeners doesn't work. When these types are duplicated in the dependant code and passed like `_client?: Client<KafkaProducerEvents | KafkaConsumerEvents>`, the event listener typings work correctly. 

Exporting these types is the least effort to enable this usecase, otherwise requiring larger changes to how the abstract class is typed. One cannot say `_client?: KafkaConsumer | Producer` because then the event listener functions have conflicting types and cannot be used at all.