### PR TITLE
fix: `util.isError` API is deprecated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [16, 18, 20, 21]
+        node: [16, 18, 20, 22]
         os: [ubuntu-22.04]
         include:
           # single mac test due to minute multipliers

--- a/lib/error.js
+++ b/lib/error.js
@@ -405,7 +405,7 @@ function LibrdKafkaError(e) {
       this.origin = 'kafka';
     }
     Error.captureStackTrace(this, this.constructor);
-  } else if (!util.isError(e)) {
+  } else if (!(Object.prototype.toString(e) === "[object Error]" || e instanceof Error)) {
     // This is the better way
     this.message = e.message;
     this.code = e.code;


### PR DESCRIPTION
When node 22 is used you get the following deprecation warning:

```
(node:3751956) [DEP0048] DeprecationWarning: The `util.isError` API is deprecated. Please use `ObjectPrototypeToString(e) === "[object Error]" || e instanceof Error` instead.
```

This fixes that and makes this repo compatible with node 22. No other changes are needed.