### PR TITLE
feat: consume from specific partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ The following table lists important methods for this API.
 |`consumer.unsubscribe()` | Unsubscribes from the currently subscribed topics. <br><br>You cannot subscribe to different topics without calling the `unsubscribe()` method first. |
 |`consumer.consume(cb)` | Gets messages from the existing subscription as quickly as possible. If `cb` is specified, invokes `cb(err, message)`. <br><br>This method keeps a background thread running to do the work. Note that the number of threads in nodejs process is limited by `UV_THREADPOOL_SIZE` (default value is 4) and using up all of them blocks other parts of the application that need threads. If you need multiple consumers then consider increasing `UV_THREADPOOL_SIZE` or using `consumer.consume(number, cb)` instead. |
 |`consumer.consume(number, cb)` | Gets `number` of messages from the existing subscription. If `cb` is specified, invokes `cb(err, message)`. |
+|`consumer.consume(number, topic, partition, cb)` | Gets `number` of messages from a partition of the given topic. The topic must have a subscription. If `cb` is specified, invokes `cb(err, message)`.
 |`consumer.commit()` | Commits all locally stored offsets |
 |`consumer.commit(topicPartition)` | Commits offsets specified by the topic partition |
 |`consumer.commitMessage(message)` | Commits the offsets specified by the message |

--- a/examples/consumer-per-partition.md
+++ b/examples/consumer-per-partition.md
@@ -1,0 +1,130 @@
+A consumer that is subscribed to multiple partitions can control the mix of messages consumed from each partition. How this is done is explained [here](https://github.com/confluentinc/librdkafka/wiki/FAQ#what-are-partition-queues-and-why-are-some-partitions-slower-than-others).
+
+The example below simulates a partition 0 which is slow (2s per consume). Other partitions consume at a rate of 0.5s. To use the example, create a topic "test" with two partitions. Produce 500 message to both partitions. This example does not require an active producer. Run the example to see the result. Run multiple instances to see the rebalancing take effect.
+
+```js
+/*
+ * node-rdkafka - Node.js wrapper for RdKafka C/C++ library
+ *
+ * Copyright (c) 2016 Blizzard Entertainment
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE.txt file for details.
+ */
+
+var Kafka = require('../');
+
+var consumer = new Kafka.KafkaConsumer({
+  //'debug': 'all',
+  'metadata.broker.list': 'localhost:9092',
+  'group.id': 'test-group-' + Math.random(),
+  'enable.auto.commit': false,
+  'rebalance_cb': true,
+}, {
+  'auto.offset.reset': 'earliest', // start from the beginning
+});
+
+var topicName = 'test';
+
+// Keep track of which partitions are assigned.
+var assignments = [];
+
+//logging debug messages, if debug is enabled
+consumer.on('event.log', function(log) {
+  console.log(log);
+});
+
+//logging all errors
+consumer.on('event.error', function(err) {
+  console.error('Error from consumer');
+  console.error(err);
+});
+
+consumer.on('ready', function(arg) {
+  console.log('consumer ready: ' + JSON.stringify(arg));
+
+  consumer.subscribe([topicName]);
+
+  // start a regular consume loop in flowing mode. This won't result in any
+  // messages because will we start consuming from a partition directly.
+  // This is required to serve the rebalancing events
+  consumer.consume();
+});
+
+// Start our own consume loops for all newly assigned partitions
+consumer.on('rebalance', function(err, updatedAssignments) {
+  console.log('rebalancing done, got partitions assigned: ', updatedAssignments.map(function(a) {
+    return a.partition;
+  }));
+
+  // Normally messages are forwarded to a general queue, which contains messages from all assigned partitions.
+  // however we want to consume per partitions, for this we need to disable forwarding.
+  updatedAssignments.forEach(function (assignment) {
+    consumer.disableQueueForwarding(assignment);
+  });
+
+  // find new assignments
+  var newAssignments = updatedAssignments.filter(function (updatedAssignment) {
+    return !assignments.some(function (assignment) {
+      return assignment.partition === updatedAssignment.partition;
+    });
+  });
+
+  // update global assignments array
+  assignments = updatedAssignments;
+
+  // then start consume loops for the new assignments
+  newAssignments.forEach(function (assignment) {
+    startConsumeMessages(assignment.partition);
+  });
+});
+
+function startConsumeMessages(partition) {
+  console.log('partition: ' + partition + ' starting to consume');
+
+  function consume() {
+    var isPartitionAssigned = assignments.some(function(assignment) {
+      return assignment.partition === partition;
+    });
+
+    if (!isPartitionAssigned) {
+      console.log('partition: ' + partition + ' stop consuming');
+      return;
+    }
+
+    // consume per 5 messages
+    consumer.consume(5, topicName, partition, callback);
+  }
+
+  function callback(err, messages) {
+    messages.forEach(function(message) {
+      // consume the message
+      console.log('partition ' + message.partition + ' value ' + message.value.toString());
+      consumer.commitMessage(message);
+    });
+
+    if (messages.length > 0) {
+      consumer.commitMessage(messages.pop());
+    }
+
+    // simulate performance
+    setTimeout(consume, partition === 0 ? 2000 : 500);
+  }
+
+  // kick-off recursive consume loop
+  consume();
+}
+
+consumer.on('disconnected', function(arg) {
+  console.log('consumer disconnected. ' + JSON.stringify(arg));
+});
+
+//starting the consumer
+consumer.connect();
+
+//stopping this example after 30s
+setTimeout(function() {
+  consumer.disconnect();
+}, 30000);
+
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -223,8 +223,9 @@ export class KafkaConsumer extends Client<KafkaConsumerEvents> {
     committed(toppars: TopicPartition[], timeout: number, cb: (err: LibrdKafkaError, topicPartitions: TopicPartitionOffset[]) => void): this;
     committed(timeout: number, cb: (err: LibrdKafkaError, topicPartitions: TopicPartitionOffset[]) => void): this;
 
-    consume(number: number, cb?: (err: LibrdKafkaError, messages: Message[]) => void): void;
-    consume(cb: (err: LibrdKafkaError, messages: Message[]) => void): void;
+    consume(number: number, topic: string, partition: number, cb?: (err: LibrdKafkaError | null, messages: Message[] | undefined) => void): void;
+    consume(number: number, cb?: (err: LibrdKafkaError | null, messages: Message[] | undefined) => void): void;
+    consume(cb: (err: LibrdKafkaError | null, messages: Message[] | undefined) => void): void;
     consume(): void;
 
     getWatermarkOffsets(topic: string, partition: number): WatermarkOffsets;
@@ -238,6 +239,8 @@ export class KafkaConsumer extends Client<KafkaConsumerEvents> {
     resume(topicPartitions: TopicPartition[]): any;
 
     seek(toppar: TopicPartitionOffset, timeout: number | null, cb: (err: LibrdKafkaError) => void): this;
+
+    disableQueueForwarding(topicPartition: TopicPartition): this;
 
     setDefaultConsumeTimeout(timeoutMs: number): void;
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -405,7 +405,7 @@ function LibrdKafkaError(e) {
       this.origin = 'kafka';
     }
     Error.captureStackTrace(this, this.constructor);
-  } else if (!util.isError(e)) {
+  } else if (!(Object.prototype.toString(e) === "[object Error]" || e instanceof Error)) {
     // This is the better way
     this.message = e.message;
     this.code = e.code;

--- a/lib/kafka-consumer.js
+++ b/lib/kafka-consumer.js
@@ -151,6 +151,11 @@ KafkaConsumer.prototype.setDefaultConsumeLoopTimeoutDelay = function(intervalMs)
   this._consumeLoopTimeoutDelay = intervalMs;
 };
 
+KafkaConsumer.prototype.disableQueueForwarding = function(topicPartition) {
+  this._client.disableQueueForwarding(topicPartition);
+  return this;
+};
+
 /**
  * Get a stream representation of this KafkaConsumer
  *
@@ -361,6 +366,20 @@ KafkaConsumer.prototype.unsubscribe = function() {
 };
 
 /**
+ * Read a number of messages from a specific topic and partition.
+ *
+ * Can be useful if the consume performance differs per partition. Consuming
+ * per partition could prevent slow performance on one partition from affecting
+ * the consumption of other partitions.
+ *
+ * To select the right partition it is required to set a topic param, because a
+ * consumer can be subscribed to multiple topics.
+ *
+ * @param {number} size - Number of messages to read
+ * @param {string} topic - Name of topic to read
+ * @param {number} partition - Identifier of partition to read
+ * @param {KafkaConsumer~readCallback} cb - Callback to return when work is done.
+ *//**
  * Read a number of messages from Kafka.
  *
  * This method is similar to the main one, except that it reads a number
@@ -384,12 +403,22 @@ KafkaConsumer.prototype.unsubscribe = function() {
  * @param {KafkaConsumer~readCallback} cb - Callback to return when a message
  * is fetched.
  */
-KafkaConsumer.prototype.consume = function(number, cb) {
+ KafkaConsumer.prototype.consume = function(number, topic, partition, cb) {
   var timeoutMs = this._consumeTimeout !== undefined ? this._consumeTimeout : DEFAULT_CONSUME_TIME_OUT;
   var self = this;
 
-  if ((number && typeof number === 'number') || (number && cb)) {
+  if ((number && typeof number === 'number') && typeof topic === 'string' && typeof partition === 'number') {
 
+    if (cb === undefined) {
+      cb = function() {};
+    } else if (typeof cb !== 'function') {
+      throw new TypeError('Callback must be a function');
+    }
+
+    this._consumeNumOfPartition(timeoutMs, number, topic, partition, cb);
+  } else if ((number && typeof number === 'number') || (number && topic)) {
+    // topic is given as the cb
+    cb = topic;
     if (cb === undefined) {
       cb = function() {};
     } else if (typeof cb !== 'function') {
@@ -496,6 +525,53 @@ KafkaConsumer.prototype._consumeNum = function(timeoutMs, numMessages, cb) {
     }
 
   });
+
+};
+
+/**
+ * Consume a number of messages from a specific topic and partition
+ * Wrapped in a try catch with proper error reporting. Should not be
+ * called directly, and instead should be called using consume.
+ *
+ * @private
+ * @see consume
+ */
+KafkaConsumer.prototype._consumeNumOfPartition = function(timeoutMs, numMessages, topic, partition, cb, onlyApplyTimeoutToFirstMessage) {
+  var self = this;
+
+  this._client.consume(timeoutMs, numMessages, topic, partition, function(err, messages, eofEvents) {
+    if (err) {
+      err = LibrdKafkaError.create(err);
+      if (cb) {
+        cb(err);
+      }
+      return;
+    }
+
+    var currentEofEventsIndex = 0;
+
+    function emitEofEventsFor(messageIndex) {
+      while (currentEofEventsIndex < eofEvents.length && eofEvents[currentEofEventsIndex].messageIndex === messageIndex) {
+        delete eofEvents[currentEofEventsIndex].messageIndex;
+        self.emit('partition.eof', eofEvents[currentEofEventsIndex])
+        ++currentEofEventsIndex;
+      }
+    }
+
+    emitEofEventsFor(-1);
+
+    for (var i = 0; i < messages.length; i++) {
+      self.emit('data', messages[i]);
+      emitEofEventsFor(i);
+    }
+
+    emitEofEventsFor(messages.length);
+
+    if (cb) {
+      cb(null, messages);
+    }
+
+  }, onlyApplyTimeoutToFirstMessage);
 
 };
 

--- a/src/kafka-consumer.h
+++ b/src/kafka-consumer.h
@@ -73,6 +73,8 @@ class KafkaConsumer : public Connection {
 
   Baton Assign(std::vector<RdKafka::TopicPartition*>);
   Baton Unassign();
+  
+  Baton DisableQueueForwarding(RdKafka::TopicPartition*);
 
   Baton Seek(const RdKafka::TopicPartition &partition, int timeout_ms);
 
@@ -107,6 +109,7 @@ class KafkaConsumer : public Connection {
   static NAN_METHOD(NodeAssign);
   static NAN_METHOD(NodeUnassign);
   static NAN_METHOD(NodeAssignments);
+  static NAN_METHOD(NodeDisableQueueForwarding);
   static NAN_METHOD(NodeUnsubscribe);
   static NAN_METHOD(NodeCommit);
   static NAN_METHOD(NodeCommitSync);

--- a/src/workers.cc
+++ b/src/workers.cc
@@ -784,6 +784,188 @@ void KafkaConsumerConsumeLoop::HandleErrorCallback() {
 }
 
 /**
+ * @brief KafkaConsumer get messages per partition worker.
+ *
+ * This callback will get a number of messages from a specific partition.
+ * Can be of use in streams or places where you don't want an infinite
+ * loop managed in C++land and would rather manage it in Node.
+ *
+ * @see RdKafka::KafkaConsumer::Consume
+ * @see NodeKafka::KafkaConsumer::GetMessage
+ */
+
+KafkaConsumerConsumeNumOfPartition::KafkaConsumerConsumeNumOfPartition(Nan::Callback *callback,
+                                     KafkaConsumer* consumer,
+                                     const uint32_t & num_messages,
+                                     const std::string topic,
+                                     const uint32_t & partition,
+                                     const int & timeout_ms,
+                                     const bool only_apply_timeout_to_first_message) :
+  ErrorAwareWorker(callback),
+  m_consumer(consumer),
+  m_num_messages(num_messages),
+  m_topic(topic),
+  m_partition(partition),
+  m_timeout_ms(timeout_ms),
+  m_only_apply_timeout_to_first_message(only_apply_timeout_to_first_message) {}
+
+KafkaConsumerConsumeNumOfPartition::~KafkaConsumerConsumeNumOfPartition() {}
+
+void KafkaConsumerConsumeNumOfPartition::Execute() {
+  std::size_t max = static_cast<std::size_t>(m_num_messages);
+  bool looping = true;
+  int timeout_ms = m_timeout_ms;
+  std::size_t eof_event_count = 0;
+
+  // Disable forwarding for own partition
+  RdKafka::TopicPartition *topicPartition = RdKafka::TopicPartition::create(
+    m_topic, m_partition);
+
+  if (topicPartition == NULL) {
+    SetErrorBaton(Baton(RdKafka::ERR__STATE,
+      "TopicPartition not found."));
+
+    return;
+  }
+
+  RdKafka::Queue *queue = m_consumer->GetClient()->get_partition_queue(
+    topicPartition);
+
+  if (queue == NULL) {
+    SetErrorBaton(Baton(RdKafka::ERR__STATE,
+      "TopicPartition has an invalid queue."));
+    delete topicPartition;
+    return;
+  }
+
+  while (m_messages.size() - eof_event_count < max && looping) {
+    if (!m_consumer->IsConnected()) {
+      if (m_messages.size() == eof_event_count) {
+        SetErrorBaton(Baton(RdKafka::ERR__STATE,
+          "KafkaConsumer is not connected"));
+      }
+      looping = false;
+      continue;
+    }
+
+    // Get a message
+    RdKafka::Message *message = queue->consume(timeout_ms);
+    RdKafka::ErrorCode errorCode = message->err();
+
+    // If true, do not wait after the first message. This will cause to consume
+    // only what has also been fetched and then return immediately
+    if (m_only_apply_timeout_to_first_message) {
+      timeout_ms = 1;
+    }
+
+    switch (errorCode) {
+      case RdKafka::ERR__PARTITION_EOF:
+        // If partition EOF and have consumed messages, retry with timeout 1
+        // This allows getting ready messages, while not waiting for new ones
+        if (m_messages.size() > eof_event_count) {
+          timeout_ms = 1;
+        }
+
+        // We will only go into this code path when `enable.partition.eof` is
+        // set to true. In this case, consumer is also interested in EOF
+        // messages, so we return an EOF message
+        m_messages.push_back(message);
+        eof_event_count += 1;
+        break;
+      case RdKafka::ERR__TIMED_OUT:
+      case RdKafka::ERR__TIMED_OUT_QUEUE:
+        // Break of the loop if we timed out
+        delete message;
+        looping = false;
+        break;
+      case RdKafka::ERR_NO_ERROR:
+        m_messages.push_back(message);
+        break;
+      default:
+        // Set the error for any other errors and break
+        delete message;
+        if (m_messages.size() == eof_event_count) {
+          SetErrorBaton(Baton(errorCode));
+        }
+        looping = false;
+        break;
+    }
+  }
+
+  delete queue;
+  delete topicPartition;
+}
+
+void KafkaConsumerConsumeNumOfPartition::HandleOKCallback() {
+  Nan::HandleScope scope;
+  const unsigned int argc = 3;
+  v8::Local<v8::Value> argv[argc];
+  argv[0] = Nan::Null();
+
+  v8::Local<v8::Array> returnArray = Nan::New<v8::Array>();
+  v8::Local<v8::Array> eofEventsArray = Nan::New<v8::Array>();
+
+  if (m_messages.size() > 0) {
+    int returnArrayIndex = -1;
+    int eofEventsArrayIndex = -1;
+    for (std::vector<RdKafka::Message*>::iterator it = m_messages.begin();
+        it != m_messages.end(); ++it) {
+      RdKafka::Message* message = *it;
+
+      switch (message->err()) {
+        case RdKafka::ERR_NO_ERROR:
+          ++returnArrayIndex;
+          Nan::Set(returnArray, returnArrayIndex, Conversion::Message::ToV8Object(message));
+          break;
+        case RdKafka::ERR__PARTITION_EOF:
+          ++eofEventsArrayIndex;
+
+          // create EOF event
+          v8::Local<v8::Object> eofEvent = Nan::New<v8::Object>();
+
+          Nan::Set(eofEvent, Nan::New<v8::String>("topic").ToLocalChecked(),
+            Nan::New<v8::String>(message->topic_name()).ToLocalChecked());
+          Nan::Set(eofEvent, Nan::New<v8::String>("offset").ToLocalChecked(),
+            Nan::New<v8::Number>(message->offset()));
+          Nan::Set(eofEvent, Nan::New<v8::String>("partition").ToLocalChecked(),
+            Nan::New<v8::Number>(message->partition()));
+
+          // also store index at which position in the message array this event was emitted
+          // this way, we can later emit it at the right point in time
+          Nan::Set(eofEvent, Nan::New<v8::String>("messageIndex").ToLocalChecked(),
+            Nan::New<v8::Number>(returnArrayIndex));
+
+          Nan::Set(eofEventsArray, eofEventsArrayIndex, eofEvent);
+      }
+
+      delete message;
+    }
+  }
+
+  argv[1] = returnArray;
+  argv[2] = eofEventsArray;
+
+  callback->Call(argc, argv);
+}
+
+void KafkaConsumerConsumeNumOfPartition::HandleErrorCallback() {
+  Nan::HandleScope scope;
+
+  if (m_messages.size() > 0) {
+    for (std::vector<RdKafka::Message*>::iterator it = m_messages.begin();
+        it != m_messages.end(); ++it) {
+      RdKafka::Message* message = *it;
+      delete message;
+    }
+  }
+
+  const unsigned int argc = 1;
+  v8::Local<v8::Value> argv[argc] = { GetErrorObject() };
+
+  callback->Call(argc, argv);
+}
+
+/**
  * @brief KafkaConsumer get messages worker.
  *
  * This callback will get a number of messages. Can be of use in streams or

--- a/src/workers.h
+++ b/src/workers.h
@@ -432,6 +432,25 @@ class KafkaConsumerSeek : public ErrorAwareWorker {
   const int m_timeout_ms;
 };
 
+class KafkaConsumerConsumeNumOfPartition : public ErrorAwareWorker {
+ public:
+  KafkaConsumerConsumeNumOfPartition(Nan::Callback*, NodeKafka::KafkaConsumer*,
+    const uint32_t &, const std::string, const uint32_t &, const int &, const bool);
+  ~KafkaConsumerConsumeNumOfPartition();
+
+  void Execute();
+  void HandleOKCallback();
+  void HandleErrorCallback();
+ private:
+  NodeKafka::KafkaConsumer * m_consumer;
+  const uint32_t m_num_messages;
+  const std::string m_topic;
+  const uint32_t m_partition;
+  const int m_timeout_ms;
+  std::vector<RdKafka::Message*> m_messages;
+  const bool m_only_apply_timeout_to_first_message;
+};
+
 class KafkaConsumerConsumeNum : public ErrorAwareWorker {
  public:
   KafkaConsumerConsumeNum(Nan::Callback*, NodeKafka::KafkaConsumer*,


### PR DESCRIPTION
Closes https://github.com/Blizzard/node-rdkafka/issues/1063

Notes:
- Currently we're running our fork in production which is using the `consume` method with the topic and partition argument. 
- I've updated the documentation and the examples to simplify getting started with this way of consuming messages.
- While debugging the code, I discovered that some of the callbacks return values which are not specified in the Typescript types. I've made changes where needed.

There are no breaking changes, therefore this could be released as a minor version upgrade. We would appreciate if this was merged so that we can remove our fork and use this package directly in production.