### PR TITLE
fix: remove deprecated util.isError usage

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -407,7 +407,7 @@ function LibrdKafkaError(e) {
       this.origin = 'kafka';
     }
     Error.captureStackTrace(this, this.constructor);
-  } else if (!util.isError(e)) {
+  } else if (!(e instanceof Error || Object.prototype.toString.call(e) === '[object Error]')) {
     // This is the better way
     this.message = e.message;
     this.code = e.code;


### PR DESCRIPTION
Fixes an existing issue https://github.com/Blizzard/node-rdkafka/issues/1117 caused by the removal of `util.isError`. `util.isError` was removed in Node.js v23 release, see https://github.com/nodejs/node/pull/52744

- Replaced util.isError(e) with instanceof Error and Object.prototype.toString.call(e) === '[object Error]'
- Ensured compatibility with Node.js v23


