### PR TITLE
Ignore librd/examples in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,7 @@ deps/*
 .gitmodules
 Dockerfile
 deps/librdkafka/config.h
-deps/librdkafka/examples
+deps/librdkafka/examples/*
 build
 .github
 .vscode

--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@ deps/*
 .gitmodules
 Dockerfile
 deps/librdkafka/config.h
+deps/librdkafka/examples
 build
 .github
 .vscode


### PR DESCRIPTION
This takes extra 50 Mb that are not needed in production code. 
```
➜  librdkafka git:(master) du -sh * | sort -h 
4.0K	CODE_OF_CONDUCT.md
4.0K	LICENSE
4.0K	LICENSE.cjson
4.0K	LICENSE.crc32c
4.0K	LICENSE.fnv1a
4.0K	LICENSE.hdrhistogram
4.0K	LICENSE.lz4
4.0K	LICENSE.murmur2
4.0K	LICENSE.nanopb
4.0K	LICENSE.pycrc
4.0K	LICENSE.queue
4.0K	LICENSE.regexp
4.0K	LICENSE.snappy
4.0K	LICENSE.tinycthread
4.0K	LICENSE.wingetopt
4.0K	Makefile
4.0K	README.win32
4.0K	config.cache
4.0K	config.h
4.0K	config.log.old
4.0K	dev-conf.sh
4.0K	lds-gen.py
4.0K	mainpage.doxy
4.0K	service.yml
4.0K	vcpkg.json
8.0K	CMakeLists.txt
8.0K	Makefile.config
8.0K	configure
 12K	LICENSE.opentelemetry
 12K	README.md
 12K	configure.self
 16K	CONTRIBUTING.md
 24K	STATISTICS.md
 32K	LICENSES.txt
 48K	config.log
 60K	CONFIGURATION.md
 68K	debian
 88K	CHANGELOG.md
104K	Doxyfile
116K	INTRODUCTION.md
164K	mklove
188K	win32
2.9M	tests
3.0M	packaging
3.2M	src-cpp
 31M	src
 55M	examples
```