### PR TITLE
Fix memory leak when fetching metadata for a single topic

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -21,6 +21,7 @@
 #include "src/errors.h"
 #include "src/config.h"
 #include "src/callbacks.h"
+#include "src/kafka-operation-result.h"
 
 namespace NodeKafka {
 
@@ -56,8 +57,8 @@ public:
   bool IsClosing();
 
   // Baton<RdKafka::Topic*>
-  Baton CreateTopic(std::string);
-  Baton CreateTopic(std::string, RdKafka::Conf*);
+  KafkaOperationResult<RdKafka::Topic> CreateTopic(std::string);
+  KafkaOperationResult<RdKafka::Topic> CreateTopic(std::string, RdKafka::Conf*);
   Baton GetMetadata(bool, std::string, int);
   Baton QueryWatermarkOffsets(std::string, int32_t, int64_t*, int64_t*, int);
   Baton OffsetsForTimes(std::vector<RdKafka::TopicPartition*> &, int);

--- a/src/kafka-operation-result.h
+++ b/src/kafka-operation-result.h
@@ -1,0 +1,63 @@
+#ifndef SRC_KAFKA_OPERATION_RESULT_H_
+#define SRC_KAFKA_OPERATION_RESULT_H_
+
+#include <cassert>
+#include <memory>
+#include <string>
+
+#include "rdkafkacpp.h"
+
+namespace NodeKafka {
+/**
+ * Type-safe wrapper for the result of an RDKafka library operation.
+ */
+template<typename T>
+class KafkaOperationResult {
+  public:
+    /**
+     * Constructor for a successful operation result.
+     * Takes ownership of the data pointer.
+     */
+    explicit KafkaOperationResult(T* data)
+      : m_data(data), m_err(RdKafka::ErrorCode::ERR_NO_ERROR) {}
+    explicit KafkaOperationResult(RdKafka::ErrorCode err)
+      : m_data(nullptr), m_err(err) {}
+    explicit KafkaOperationResult(RdKafka::ErrorCode err, std::string errstr)
+      : m_data(nullptr), m_err(err), m_errstr(errstr) {}
+
+    /**
+     * Get a non-owning pointer to the result data.
+     * Only should be called for non-error results.
+     */
+    T* data() const {
+      assert(m_data != nullptr);
+      return m_data.get();
+    }
+
+    /**
+     * Transfer ownership of the result data to the caller.
+     * Only should be called for non-error results.
+     */
+    std::unique_ptr<T> take_ownership() {
+      assert(m_data != nullptr);
+      std::unique_ptr<T> data = std::move(m_data);
+      m_data.reset();
+      return data;
+    }
+
+    RdKafka::ErrorCode err() const {
+      return m_err;
+    }
+
+    std::string errstr() const {
+      return m_errstr.empty() ? RdKafka::err2str(m_err) : m_errstr;
+    }
+
+  private:
+    std::unique_ptr<T> m_data;
+    RdKafka::ErrorCode m_err;
+    std::string m_errstr;
+};
+} // namespace NodeKafka
+
+#endif  // SRC_KAFKA_OPERATION_RESULT_H_

--- a/src/topic.cc
+++ b/src/topic.cc
@@ -45,7 +45,7 @@ std::string Topic::name() {
   return m_topic_name;
 }
 
-Baton Topic::toRDKafkaTopic(Connection* handle) {
+KafkaOperationResult<RdKafka::Topic> Topic::toRDKafkaTopic(Connection* handle) {
   if (m_config) {
     return handle->CreateTopic(m_topic_name, m_config);
   } else {

--- a/src/topic.h
+++ b/src/topic.h
@@ -16,6 +16,7 @@
 #include "rdkafkacpp.h"
 
 #include "src/config.h"
+#include "src/kafka-operation-result.h"
 
 namespace NodeKafka {
 
@@ -24,7 +25,7 @@ class Topic : public Nan::ObjectWrap {
   static void Init(v8::Local<v8::Object>);
   static v8::Local<v8::Object> NewInstance(v8::Local<v8::Value> arg);
 
-  Baton toRDKafkaTopic(Connection *handle);
+  KafkaOperationResult<RdKafka::Topic> toRDKafkaTopic(Connection *handle);
 
  protected:
   static Nan::Persistent<v8::Function> constructor;


### PR DESCRIPTION
When requesting metadata for a single topic, Connection::GetMetadata() calls Connection::CreateTopic() to resolve the provided topic name into a Topic, but fails to deallocate it.

To reproduce, compile node-rdkafka and librdkafka with ASAN, then run the following:

```js
const { KafkaConsumer } = require('.');

const consumer = new KafkaConsumer({
  'group.id': 'kafka',
  'metadata.broker.list': 'localhost:9092',
}, {});

consumer.connect({ timeout: 2000 }, function (err) {
  if (err) {
    console.error('Error connecting to Kafka:', err);
    return;
  }

  consumer.getMetadata({ topic: 'test' }, function (metadataErr, metadata) {
    if (metadataErr) {
      console.error('Error fetching metadata:', metadataErr);
    } else {
      console.log(`Metadata: ${JSON.stringify(metadata, null, 2)}`);
    }

    consumer.disconnect();
  });
})
```

ASAN will report a leak from GetMetadata():
```
Indirect leak of 1048 byte(s) in 1 object(s) allocated from:
    #0 0x7f9dd63fa037 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x7f9dab530394 in rd_calloc /node-rdkafka/deps/librdkafka/src/rd.h:134
    #2 0x7f9dab530394 in rd_kafka_topic_new0 /node-rdkafka/deps/librdkafka/src/rdkafka_topic.c:349
    #3 0x7f9dab534cbc in rd_kafka_topic_new /node-rdkafka/deps/librdkafka/src/rdkafka_topic.c:533
    #4 0x7f9dd1f47891 in RdKafka::Topic::create(RdKafka::Handle*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, RdKafka::Conf const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /node-rdkafka/deps/librdkafka/src-cpp/TopicImpl.cpp:114
    #5 0x7f9dabdc8eb9 in NodeKafka::Connection::CreateTopic(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RdKafka::Conf*) ../src/connection.cc:115
    #6 0x7f9dabdc94db in NodeKafka::Connection::CreateTopic(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) ../src/connection.cc:104
    #7 0x7f9dabdca0d9 in NodeKafka::Connection::GetMetadata(bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int) ../src/connection.cc:198
    #8 0x7f9dabe63bf2 in NodeKafka::Workers::ConnectionMetadata::Execute() ../src/workers.cc:95
    #9 0x7f9dabdd7261 in Nan::AsyncExecute(uv_work_s*) ../node_modules/nan/nan.h:2356
    #10 0x18bb06f in worker ../deps/uv/src/threadpool.c:122
    #11 0x7f9dd5ffbea6 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x7ea6)

Indirect leak of 128 byte(s) in 1 object(s) allocated from:
    #0 0x7f9dd63fa1f8 in __interceptor_realloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:164
    #1 0x7f9dab6bf9eb in rd_realloc /node-rdkafka/deps/librdkafka/src/rd.h:146
    #2 0x7f9dab6bf9eb in rd_list_grow /node-rdkafka/deps/librdkafka/src/rdlist.c:49
    #3 0x7f9dab6bfa9f in rd_list_init /node-rdkafka/deps/librdkafka/src/rdlist.c:57
    #4 0x7f9dab530dd7 in rd_kafka_topic_new0 /node-rdkafka/deps/librdkafka/src/rdkafka_topic.c:478
    #5 0x7f9dab534cbc in rd_kafka_topic_new /node-rdkafka/deps/librdkafka/src/rdkafka_topic.c:533
    #6 0x7f9dd1f47891 in RdKafka::Topic::create(RdKafka::Handle*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, RdKafka::Conf const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /node-rdkafka/deps/librdkafka/src-cpp/TopicImpl.cpp:114
    #7 0x7f9dabdc8eb9 in NodeKafka::Connection::CreateTopic(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RdKafka::Conf*) ../src/connection.cc:115
    #8 0x7f9dabdc94db in NodeKafka::Connection::CreateTopic(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) ../src/connection.cc:104
    #9 0x7f9dabdca0d9 in NodeKafka::Connection::GetMetadata(bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int) ../src/connection.cc:198
    #10 0x7f9dabe63bf2 in NodeKafka::Workers::ConnectionMetadata::Execute() ../src/workers.cc:95
    #11 0x7f9dabdd7261 in Nan::AsyncExecute(uv_work_s*) ../node_modules/nan/nan.h:2356
    #12 0x18bb06f in worker ../deps/uv/src/threadpool.c:122
    #13 0x7f9dd5ffbea6 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x7ea6)

Indirect leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7f9dd63fb647 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x7f9dd1f47743 in RdKafka::Topic::create(RdKafka::Handle*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, RdKafka::Conf const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /node-rdkafka/deps/librdkafka/src-cpp/TopicImpl.cpp:84
    #2 0x7f9dabdc8eb9 in NodeKafka::Connection::CreateTopic(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RdKafka::Conf*) ../src/connection.cc:115
    #3 0x7f9dabdc94db in NodeKafka::Connection::CreateTopic(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) ../src/connection.cc:104
    #4 0x7f9dabdca0d9 in NodeKafka::Connection::GetMetadata(bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int) ../src/connection.cc:198
    #5 0x7f9dabe63bf2 in NodeKafka::Workers::ConnectionMetadata::Execute() ../src/workers.cc:95
    #6 0x7f9dabdd7261 in Nan::AsyncExecute(uv_work_s*) ../node_modules/nan/nan.h:2356
    #7 0x18bb06f in worker ../deps/uv/src/threadpool.c:122
    #8 0x7f9dd5ffbea6 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x7ea6)

Indirect leak of 23 byte(s) in 1 object(s) allocated from:
    #0 0x7f9dd63f9e8f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f9dab5303ea in rd_malloc /node-rdkafka/deps/librdkafka/src/rd.h:140
    #2 0x7f9dab5303ea in rd_kafkap_str_new /node-rdkafka/deps/librdkafka/src/rdkafka_proto.h:315
    #3 0x7f9dab5303ea in rd_kafka_topic_new0 /node-rdkafka/deps/librdkafka/src/rdkafka_topic.c:353
    #4 0x7f9dab534cbc in rd_kafka_topic_new /node-rdkafka/deps/librdkafka/src/rdkafka_topic.c:533
    #5 0x7f9dd1f47891 in RdKafka::Topic::create(RdKafka::Handle*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, RdKafka::Conf const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /node-rdkafka/deps/librdkafka/src-cpp/TopicImpl.cpp:114
    #6 0x7f9dabdc8eb9 in NodeKafka::Connection::CreateTopic(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RdKafka::Conf*) ../src/connection.cc:115
    #7 0x7f9dabdc94db in NodeKafka::Connection::CreateTopic(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) ../src/connection.cc:104
    #8 0x7f9dabdca0d9 in NodeKafka::Connection::GetMetadata(bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int) ../src/connection.cc:198
    #9 0x7f9dabe63bf2 in NodeKafka::Workers::ConnectionMetadata::Execute() ../src/workers.cc:95
    #10 0x7f9dabdd7261 in Nan::AsyncExecute(uv_work_s*) ../node_modules/nan/nan.h:2356
    #11 0x18bb06f in worker ../deps/uv/src/threadpool.c:122
    #12 0x7f9dd5ffbea6 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x7ea6)

Indirect leak of 20 byte(s) in 2 object(s) allocated from:
    #0 0x7f9dd63a7817 in __interceptor_strdup ../../../../src/libsanitizer/asan/asan_interceptors.cpp:452
    #1 0x7f9dab537302 in rd_strdup /node-rdkafka/deps/librdkafka/src/rd.h:157
    #2 0x7f9dab537302 in rd_kafka_anyconf_set_prop0 /node-rdkafka/deps/librdkafka/src/rdkafka_conf.c:1827
    #3 0x7f9dab537c63 in rd_kafka_defaultconf_set /node-rdkafka/deps/librdkafka/src/rdkafka_conf.c:2273
    #4 0x7f9dab5394fd in rd_kafka_topic_conf_new /node-rdkafka/deps/librdkafka/src/rdkafka_conf.c:2293
    #5 0x7f9dab539e9f in rd_kafka_topic_conf_dup /node-rdkafka/deps/librdkafka/src/rdkafka_conf.c:2725
    #6 0x7f9dd1f4794f in RdKafka::Topic::create(RdKafka::Handle*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, RdKafka::Conf const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /node-rdkafka/deps/librdkafka/src-cpp/TopicImpl.cpp:89
    #7 0x7f9dabdc8eb9 in NodeKafka::Connection::CreateTopic(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RdKafka::Conf*) ../src/connection.cc:115
    #8 0x7f9dabdc94db in NodeKafka::Connection::CreateTopic(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) ../src/connection.cc:104
    #9 0x7f9dabdca0d9 in NodeKafka::Connection::GetMetadata(bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int) ../src/connection.cc:198
    #10 0x7f9dabe63bf2 in NodeKafka::Workers::ConnectionMetadata::Execute() ../src/workers.cc:95
    #11 0x7f9dabdd7261 in Nan::AsyncExecute(uv_work_s*) ../node_modules/nan/nan.h:2356
    #12 0x18bb06f in worker ../deps/uv/src/threadpool.c:122
    #13 0x7f9dd5ffbea6 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x7ea6)
```

The main issue seems to be that `Baton` does not take ownership of pointers it receives, requiring callers to manually dispose of the data on an ad-hoc basis. So, introduce a new typed RAII wrapper class suitable for wrapping the results of a librdkafka operation, and convert CreateTopic() to return it instead.

As a potential followup, other methods that currently return a `Baton` could also be incrementally migrated to the new wrapper to reduce the amount of manual memory management required.