### PR TITLE
Fix: segfault due to use after free in workers thread

### DIFF
--- a/src/workers.cc
+++ b/src/workers.cc
@@ -767,10 +767,7 @@ void KafkaConsumerConsumeLoop::HandleMessageCallback(RdKafka::Message* msg, RdKa
     delete msg;
   }
 
-  // Don't call after work completed
-  if (callback && !callback->IsEmpty()) {
-    callback->Call(argc, argv);
-  }
+  callback->Call(argc, argv);
 }
 
 void KafkaConsumerConsumeLoop::HandleOKCallback() {


### PR DESCRIPTION
When NodeDisconnect calls worker.WorkComplete() and Destroy() sets the callback to null, while the thread is stopping or starting in a race, creating "use after free" segmentation fault in the message callback handler on Linux.

Closes: https://github.com/Blizzard/node-rdkafka/issues/1057

cc: @GaryWilber 